### PR TITLE
[UI/#33] 이용약관/휴대폰인증/닉네임입력 뷰 구현

### DIFF
--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/button/LargeButton.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/button/LargeButton.kt
@@ -25,12 +25,12 @@ import com.sopt.withsuhyeon.ui.theme.defaultWithSuhyeonTypography
 
 @Composable
 fun LargeButton(
+    onClick: () -> Unit,
     text: String,
     isDisabled: Boolean = false,
     isDownloadBtn: Boolean = false,
     modifier: Modifier = Modifier,
     font: TextStyle = defaultWithSuhyeonTypography.body01_B,
-    onClick: () -> Unit,
 ) {
     val backgroundColor: Color
     val textColor: Color

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/button/ShowButton.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/button/ShowButton.kt
@@ -20,11 +20,11 @@ import com.sopt.withsuhyeon.ui.theme.defaultWithSuhyeonTypography
 
 @Composable
 fun ShowButton(
-    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
     text: String = "보기",
     font: TextStyle = defaultWithSuhyeonTypography.body03_SB,
     color: Color = Grey500,
-    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Text(
         modifier = modifier

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/checkbox/CheckBox.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/checkbox/CheckBox.kt
@@ -33,11 +33,12 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 @Composable
 fun CheckBox(
     placeholder: String,
+    onClick: () -> Unit,
     type: String = "primary",
     state: String = "default",
-    modifier: Modifier = Modifier,
     font: TextStyle = typography.body03_SB,
-    onClick: () -> Unit
+    modifier: Modifier = Modifier,
+//    TODO :
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
@@ -87,7 +88,7 @@ fun CheckBox(
             modifier = modifier
                 .width(20.dp)
                 .height(20.dp)
-                .padding(horizontal = 4.dp, vertical = 4.dp)
+                .padding(2.dp)
                 .background(backgroundColor, shape = RoundedCornerShape(size = 6.dp))
                 .noRippleClickable(onClick)
         ) {
@@ -121,7 +122,9 @@ fun CheckBoxPreview(
         ) {
             CheckBox(
                 placeholder = "플레이스 홀더",
-                onClick = {}
+                onClick = {
+                // TODO - 선택 state 변하게
+                }
             )
             CheckBox(
                 placeholder = "플레이스 홀더",

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/progressbar/AnimatedProgressBar.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/progressbar/AnimatedProgressBar.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.runtime.Composable
@@ -45,7 +44,6 @@ fun AnimatedProgressBar(
             .background(
                 color = colors.White
             )
-            .padding(16.dp)
             .fillMaxWidth()
             .height(8.dp)
             .background(

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/BasicShortTextField.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/BasicShortTextField.kt
@@ -237,7 +237,6 @@ fun PreviewFullOptionBasicShortTextField() {
                 errorMessage = if (!isValid) "\"텍스트\"라고 입력해주세요." else ""
                 value = input
                 enabled = value != "불가"
-
             },
             errorMessage = errorMessage,
             visibleLength = true,

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/BasicShortTextField.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/BasicShortTextField.kt
@@ -60,9 +60,9 @@ fun BasicShortTextField(
     var isMaxLengthExceeded by remember { mutableStateOf(false) }
     val borderColor =
         when {
+            value.isNotEmpty() && !isValid -> colors.Red01
             isMaxLengthExceeded -> colors.Red01
             isFocused -> colors.Purple300
-            value.isNotEmpty() && enabled && !isValid -> colors.Red01
             else -> colors.Grey100
         }
     val textColor = if (enabled) colors.Grey900 else colors.Grey300
@@ -151,7 +151,6 @@ fun BasicShortTextField(
                     modifier = Modifier.weight(1f)
                 )
             } else if (value.isNotEmpty()
-                && !isFocused
                 && !isValid
                 && enabled
                 && errorMessage.isNotEmpty()

--- a/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
@@ -5,6 +5,10 @@ import kotlinx.serialization.Serializable
 sealed interface Route {
     @Serializable
     data object TermsOfUse : Route
+    @Serializable
+    data object PhoneNumberAuth : Route
+    @Serializable
+    data object NickNameAuth : Route
 }
 
 sealed interface MainTabRoute : Route {

--- a/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 sealed interface Route {
     @Serializable
-    data object OnBoarding : Route
+    data object TermsOfUse : Route
 }
 
 sealed interface MainTabRoute : Route {

--- a/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
@@ -9,6 +9,8 @@ sealed interface Route {
     data object PhoneNumberAuth : Route
     @Serializable
     data object NickNameAuth : Route
+    @Serializable
+    data object SelectYearOfBirth : Route
 }
 
 sealed interface MainTabRoute : Route {

--- a/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
@@ -31,4 +31,9 @@ object KeyStorage {
     const val NEXT_BUTTON_TEXT = "다음"
     const val BEFORE_SEND_BUTTON_TEXT = "인증요청"
     const val AFTER_SEND_BUTTON_TEXT = "전송완료"
+
+    const val LENGTH_ERROR = "lengthError"
+    const val SPECIAL_CHARACTER_ERROR = "specialError"
+    const val LENGTH_ERROR_MESSAGE = "최대 12글자 이하로 입력해주세요"
+    const val SPECIAL_CHARACTER_ERROR_MESSAGE = "특수기호를 제거해주세요"
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
@@ -36,4 +36,6 @@ object KeyStorage {
     const val SPECIAL_CHARACTER_ERROR = "specialError"
     const val LENGTH_ERROR_MESSAGE = "최대 12글자 이하로 입력해주세요"
     const val SPECIAL_CHARACTER_ERROR_MESSAGE = "특수기호를 제거해주세요"
+
+    const val EMPTY_STRING =""
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
@@ -29,4 +29,6 @@ object KeyStorage {
     const val FIND_SUHYEON_DETAIL_MEETING_INFORMATION_EXPAND = "expand_item"
 
     const val NEXT_BUTTON_TEXT = "다음"
+    const val BEFORE_SEND_BUTTON_TEXT = "인증요청"
+    const val AFTER_SEND_BUTTON_TEXT = "전송완료"
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
@@ -6,6 +6,7 @@ object KeyStorage {
     const val DISABLED_TYPE = "disabled"
     const val SECONDARY_TYPE = "secondary"
     const val CHECKED = "checked"
+    const val DEFAULT = "default"
     const val SHORT_TEXTFIELD_MAX_LENGTH = 30
 
     //수현이 찾기 - MultiSelectChip
@@ -26,4 +27,6 @@ object KeyStorage {
     const val SHORT_MALE = "남"
 
     const val FIND_SUHYEON_DETAIL_MEETING_INFORMATION_EXPAND = "expand_item"
+
+    const val NEXT_BUTTON_TEXT = "다음"
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
@@ -28,7 +28,7 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Route.NickNameAuth
+    val startDestination = Route.TermsOfUse
 
     val currentTab: MainTab?
         @SuppressLint("RestrictedApi") @Composable get() = MainTab.find { tab ->

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
@@ -16,7 +16,7 @@ import com.sopt.withsuhyeon.feature.findsuhyeon.navigation.navigateToFindSuhyeon
 import com.sopt.withsuhyeon.feature.gallery.navigation.navigateToGallery
 import com.sopt.withsuhyeon.feature.home.navigation.navigateToHome
 import com.sopt.withsuhyeon.feature.mypage.navigation.navigateToMyPage
-import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToOnBoarding
+import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToTermsOfUse
 
 class MainNavigator(
     val navController: NavHostController,
@@ -25,7 +25,7 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Route.OnBoarding
+    val startDestination = Route.TermsOfUse
 
     val currentTab: MainTab?
         @SuppressLint("RestrictedApi") @Composable get() = MainTab.find { tab ->
@@ -50,8 +50,8 @@ class MainNavigator(
         }
     }
 
-    fun navigateToOnBoarding() {
-        navController.navigateToOnBoarding()
+    fun navigateToTermsOfUse() {
+        navController.navigateToTermsOfUse()
     }
 
     fun navigateToHome(navOptions: NavOptions? = null) {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
@@ -16,7 +16,9 @@ import com.sopt.withsuhyeon.feature.findsuhyeon.navigation.navigateToFindSuhyeon
 import com.sopt.withsuhyeon.feature.gallery.navigation.navigateToGallery
 import com.sopt.withsuhyeon.feature.home.navigation.navigateToHome
 import com.sopt.withsuhyeon.feature.mypage.navigation.navigateToMyPage
-import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToTermsOfUse
+import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToNickNameAuth
+import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToPhoneNumberAuth
+
 
 class MainNavigator(
     val navController: NavHostController,
@@ -25,7 +27,7 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Route.TermsOfUse
+    val startDestination = Route.PhoneNumberAuth
 
     val currentTab: MainTab?
         @SuppressLint("RestrictedApi") @Composable get() = MainTab.find { tab ->
@@ -49,9 +51,12 @@ class MainNavigator(
             MainTab.MYPAGE -> navController.navigateToMyPage(navOptions)
         }
     }
+    fun navigateToPhoneNumberAuth() {
+        navController.navigateToPhoneNumberAuth()
+    }
 
-    fun navigateToTermsOfUse() {
-        navController.navigateToTermsOfUse()
+    fun navigateToNicknameAuth() {
+        navController.navigateToNickNameAuth()
     }
 
     fun navigateToHome(navOptions: NavOptions? = null) {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
@@ -18,6 +18,7 @@ import com.sopt.withsuhyeon.feature.home.navigation.navigateToHome
 import com.sopt.withsuhyeon.feature.mypage.navigation.navigateToMyPage
 import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToNickNameAuth
 import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToPhoneNumberAuth
+import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToSelectYearOfBirth
 
 
 class MainNavigator(
@@ -27,7 +28,7 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    val startDestination = Route.PhoneNumberAuth
+    val startDestination = Route.NickNameAuth
 
     val currentTab: MainTab?
         @SuppressLint("RestrictedApi") @Composable get() = MainTab.find { tab ->
@@ -57,6 +58,10 @@ class MainNavigator(
 
     fun navigateToNicknameAuth() {
         navController.navigateToNickNameAuth()
+    }
+
+    fun navigateToSelectYearOfBirth() {
+        navController.navigateToSelectYearOfBirth()
     }
 
     fun navigateToHome(navOptions: NavOptions? = null) {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
@@ -49,7 +49,8 @@ fun MainNavHost(
             )
             onBoardingNavGraph(
                 onNavigateToPhoneNumberAuth = navigator::navigateToPhoneNumberAuth,
-                onNavigateToNickNameAuth = navigator::navigateToNicknameAuth
+                onNavigateToNickNameAuth = navigator::navigateToNicknameAuth,
+                onNavigateToSelectYearOfBirth = navigator::navigateToSelectYearOfBirth
             )
         }
     }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
@@ -13,7 +13,7 @@ import com.sopt.withsuhyeon.feature.gallery.navigation.galleryNavGraph
 import com.sopt.withsuhyeon.feature.home.navigation.homeNavGraph
 import com.sopt.withsuhyeon.feature.main.MainNavigator
 import com.sopt.withsuhyeon.feature.mypage.navigation.myPageNavGraph
-import com.sopt.withsuhyeon.feature.onboarding.navigation.termsOfUseNavGraph
+import com.sopt.withsuhyeon.feature.onboarding.navigation.onBoardingNavGraph
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 
 @Composable
@@ -47,9 +47,9 @@ fun MainNavHost(
             myPageNavGraph(
                 padding = padding,
             )
-            termsOfUseNavGraph(
-                padding = padding,
-                onNavigateToNext = navigator::navigateToHome,
+            onBoardingNavGraph(
+                onNavigateToPhoneNumberAuth = navigator::navigateToPhoneNumberAuth,
+                onNavigateToNickNameAuth = navigator::navigateToNicknameAuth
             )
         }
     }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
@@ -13,7 +13,7 @@ import com.sopt.withsuhyeon.feature.gallery.navigation.galleryNavGraph
 import com.sopt.withsuhyeon.feature.home.navigation.homeNavGraph
 import com.sopt.withsuhyeon.feature.main.MainNavigator
 import com.sopt.withsuhyeon.feature.mypage.navigation.myPageNavGraph
-import com.sopt.withsuhyeon.feature.onboarding.navigation.onBoardingNavGraph
+import com.sopt.withsuhyeon.feature.onboarding.navigation.termsOfUseNavGraph
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 
 @Composable
@@ -47,9 +47,9 @@ fun MainNavHost(
             myPageNavGraph(
                 padding = padding,
             )
-            onBoardingNavGraph(
+            termsOfUseNavGraph(
                 padding = padding,
-                onNavigateToHome = navigator::navigateToHome,
+                onNavigateToNext = navigator::navigateToHome,
             )
         }
     }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
@@ -19,13 +19,17 @@ import com.sopt.withsuhyeon.R
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
 import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
+import com.sopt.withsuhyeon.core.util.KeyStorage.DEFAULT
+import com.sopt.withsuhyeon.core.util.KeyStorage.LENGTH_ERROR
+import com.sopt.withsuhyeon.core.util.KeyStorage.LENGTH_ERROR_MESSAGE
 import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
+import com.sopt.withsuhyeon.core.util.KeyStorage.SPECIAL_CHARACTER_ERROR
+import com.sopt.withsuhyeon.core.util.KeyStorage.SPECIAL_CHARACTER_ERROR_MESSAGE
 import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
 
 @Composable
 fun NickNameAuthenticationRoute(
     navigateToNext: () -> Unit,
-    viewModel: OnBoardingViewModel = hiltViewModel()
 ) {
     NickNameAuthenticationScreen(
         onButtonClick = navigateToNext
@@ -35,11 +39,22 @@ fun NickNameAuthenticationRoute(
 @Composable
 fun NickNameAuthenticationScreen(
     onButtonClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: OnBoardingViewModel = hiltViewModel()
 ) {
     var nicknameValue by remember { mutableStateOf("") }
     var isNicknameValid by remember { mutableStateOf(false) }
+    var nicknameErrorType by remember { mutableStateOf(LENGTH_ERROR) }
     var isNicknameTextFiledFocused by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf("") }
+
+    fun updateErrorMessage(validationState: String) {
+        errorMessage = when (validationState) {
+            LENGTH_ERROR -> LENGTH_ERROR_MESSAGE
+            SPECIAL_CHARACTER_ERROR -> SPECIAL_CHARACTER_ERROR_MESSAGE
+            else -> ""
+        }
+    }
 
     Column(
         modifier = modifier
@@ -64,18 +79,19 @@ fun NickNameAuthenticationScreen(
                 isNicknameTextFiledFocused = it
             },
             onValueChange = { input ->
-                isNicknameValid = input.length in 2..12
                 nicknameValue = input
+                nicknameErrorType = viewModel.isNicknameValid(input)
+                updateErrorMessage(nicknameErrorType)
+                isNicknameValid = nicknameErrorType == DEFAULT
             },
             maxLength = 12,
-            errorMessage = stringResource(R.string.onboarding_nickname_max_input_error_message),
+            errorMessage = errorMessage
         )
-        // TODO - 특수기호나 각종 에러 케이스 뷰모델 구현
         Spacer(modifier = Modifier.weight(1f))
         LargeButton(
             onClick = onButtonClick,
             text = NEXT_BUTTON_TEXT,
-            isDisabled = !isNicknameValid,
+            isDisabled = nicknameErrorType != DEFAULT,
         )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
@@ -1,2 +1,81 @@
 package com.sopt.withsuhyeon.feature.onboarding
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.component.button.LargeButton
+import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
+import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
+import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
+import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
+
+@Composable
+fun NickNameAuthenticationRoute(
+    navigateToNext: () -> Unit,
+    viewModel: OnBoardingViewModel = hiltViewModel()
+) {
+    NickNameAuthenticationScreen(
+        onButtonClick = navigateToNext
+    )
+}
+
+@Composable
+fun NickNameAuthenticationScreen(
+    onButtonClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var nicknameValue by remember { mutableStateOf("") }
+    var isNicknameValid by remember { mutableStateOf(false) }
+    var isNicknameTextFiledFocused by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+            .fillMaxHeight(),
+    ) {
+        AnimatedProgressBar(progress = 0.5f)
+        Spacer(
+            modifier = Modifier.height(16.dp)
+        )
+        OnBoardingTitle(text = stringResource(R.string.onboarding_nickname_screen_title))
+        Spacer(
+            modifier = Modifier.height(32.dp)
+        )
+        BasicShortTextField(
+            value = nicknameValue,
+            title = stringResource(R.string.onboarding_nickname_input_title),
+            hint = stringResource(R.string.onboarding_nickname_input_hint),
+            isValid = isNicknameValid,
+            onFocusChange = {
+                isNicknameTextFiledFocused = it
+            },
+            onValueChange = { input ->
+                isNicknameValid = input.length in 2..12
+                nicknameValue = input
+            },
+            maxLength = 12,
+            errorMessage = stringResource(R.string.onboarding_nickname_max_input_error_message),
+        )
+        // TODO - 특수기호나 각종 에러 케이스 뷰모델 구현
+        Spacer(modifier = Modifier.weight(1f))
+        LargeButton(
+            onClick = onButtonClick,
+            text = NEXT_BUTTON_TEXT,
+            isDisabled = !isNicknameValid,
+        )
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
@@ -1,11 +1,12 @@
 package com.sopt.withsuhyeon.feature.onboarding
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,13 +20,16 @@ import com.sopt.withsuhyeon.R
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
 import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
+import com.sopt.withsuhyeon.core.component.topbar.MainTopNavBar
 import com.sopt.withsuhyeon.core.util.KeyStorage.DEFAULT
+import com.sopt.withsuhyeon.core.util.KeyStorage.EMPTY_STRING
 import com.sopt.withsuhyeon.core.util.KeyStorage.LENGTH_ERROR
 import com.sopt.withsuhyeon.core.util.KeyStorage.LENGTH_ERROR_MESSAGE
 import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
 import com.sopt.withsuhyeon.core.util.KeyStorage.SPECIAL_CHARACTER_ERROR
 import com.sopt.withsuhyeon.core.util.KeyStorage.SPECIAL_CHARACTER_ERROR_MESSAGE
 import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 
 @Composable
 fun NickNameAuthenticationRoute(
@@ -42,26 +46,34 @@ fun NickNameAuthenticationScreen(
     modifier: Modifier = Modifier,
     viewModel: OnBoardingViewModel = hiltViewModel()
 ) {
-    var nicknameValue by remember { mutableStateOf("") }
+    var nicknameValue by remember { mutableStateOf(EMPTY_STRING) }
     var isNicknameValid by remember { mutableStateOf(false) }
     var nicknameErrorType by remember { mutableStateOf(LENGTH_ERROR) }
     var isNicknameTextFiledFocused by remember { mutableStateOf(false) }
-    var errorMessage by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf(EMPTY_STRING) }
 
     fun updateErrorMessage(validationState: String) {
         errorMessage = when (validationState) {
             LENGTH_ERROR -> LENGTH_ERROR_MESSAGE
             SPECIAL_CHARACTER_ERROR -> SPECIAL_CHARACTER_ERROR_MESSAGE
-            else -> ""
+            else -> EMPTY_STRING
         }
     }
 
     Column(
         modifier = modifier
-            .padding(16.dp)
-            .fillMaxWidth()
-            .fillMaxHeight(),
+            .background(color = colors.White)
+            .padding(
+                vertical = 16.dp,
+                horizontal = 16.dp
+            )
+            .fillMaxSize()
+
     ) {
+        MainTopNavBar(
+            text = EMPTY_STRING,
+            modifier = Modifier.padding(20.dp)
+        )
         AnimatedProgressBar(progress = 0.5f)
         Spacer(
             modifier = Modifier.height(16.dp)
@@ -88,6 +100,13 @@ fun NickNameAuthenticationScreen(
             errorMessage = errorMessage
         )
         Spacer(modifier = Modifier.weight(1f))
+
+        HorizontalDivider(
+            modifier = Modifier.height(1.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         LargeButton(
             onClick = onButtonClick,
             text = NEXT_BUTTON_TEXT,

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/NicknameAuthentication.kt
@@ -1,0 +1,2 @@
+package com.sopt.withsuhyeon.feature.onboarding
+

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/OnBoardingViewModel.kt
@@ -1,11 +1,23 @@
 package com.sopt.withsuhyeon.feature.onboarding
 
 import androidx.lifecycle.ViewModel
+import com.sopt.withsuhyeon.core.util.KeyStorage.DEFAULT
+import com.sopt.withsuhyeon.core.util.KeyStorage.LENGTH_ERROR
+import com.sopt.withsuhyeon.core.util.KeyStorage.SPECIAL_CHARACTER_ERROR
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class OnBoardingViewModel @Inject constructor(
 ) : ViewModel() {
+    fun isNicknameValid(nickname: String): String {
+        if (nickname.length !in 2..12) return LENGTH_ERROR
+        if (containsSpecialCharacters(nickname)) return SPECIAL_CHARACTER_ERROR
+        return DEFAULT
+    }
 
+    private fun containsSpecialCharacters(input: String): Boolean {
+        val specialCharactersRegex = "[^a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ0-9\\s]".toRegex()
+        return specialCharactersRegex.containsMatchIn(input)
+    }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/PhoneNumberAuthenticationScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/PhoneNumberAuthenticationScreen.kt
@@ -1,11 +1,12 @@
 package com.sopt.withsuhyeon.feature.onboarding
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,10 +21,13 @@ import com.sopt.withsuhyeon.core.component.button.BasicButtonForTextField
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
 import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
+import com.sopt.withsuhyeon.core.component.topbar.MainTopNavBar
 import com.sopt.withsuhyeon.core.util.KeyStorage.AFTER_SEND_BUTTON_TEXT
 import com.sopt.withsuhyeon.core.util.KeyStorage.BEFORE_SEND_BUTTON_TEXT
+import com.sopt.withsuhyeon.core.util.KeyStorage.EMPTY_STRING
 import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
 import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 
 @Composable
 fun PhoneNumberAuthenticationRoute(
@@ -40,22 +44,30 @@ fun PhoneNumberAuthenticationScreen(
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var phoneNumberValue by remember { mutableStateOf("") }
+    var phoneNumberValue by remember { mutableStateOf(EMPTY_STRING) }
     var isPhoneNumberInputValid by remember { mutableStateOf(false) }
     var isPhoneNumberInputFocused by remember { mutableStateOf(false) }
     var isPhoneNumberAuthVisible by remember { mutableStateOf(false) }
     var isPhoneNumberAuthButtonEnabled by remember { mutableStateOf(false) }
     var phoneNumberAuthButtonText by remember { mutableStateOf(BEFORE_SEND_BUTTON_TEXT) }
-    var authNumberValue by remember { mutableStateOf("") }
+    var authNumberValue by remember { mutableStateOf(EMPTY_STRING) }
     var isAuthNumberInputValid by remember { mutableStateOf(false) }
     var isAuthNumberInputFocused by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
-            .padding(16.dp)
-            .fillMaxWidth()
-            .fillMaxHeight(),
+            .background(color = colors.White)
+            .padding(
+                vertical = 16.dp,
+                horizontal = 16.dp
+            )
+            .fillMaxSize()
+
     ) {
+        MainTopNavBar(
+            text = EMPTY_STRING,
+            modifier = Modifier.padding(20.dp)
+        )
         AnimatedProgressBar(progress = 0.33f)
         Spacer(
             modifier = Modifier.height(16.dp)
@@ -78,7 +90,6 @@ fun PhoneNumberAuthenticationScreen(
                 phoneNumberValue = input
             },
             maxLength = 11,
-            errorMessage = stringResource(R.string.onboarding_phone_number_duplication_error_message),
             trailingContent = {
                 BasicButtonForTextField(
                     text = phoneNumberAuthButtonText,
@@ -109,10 +120,16 @@ fun PhoneNumberAuthenticationScreen(
                     authNumberValue = input
                 },
                 maxLength = 6,
-                errorMessage = stringResource(R.string.onboarding_phone_number_duplication_error_message),
             )
         }
         Spacer(modifier = Modifier.weight(1f))
+
+        HorizontalDivider(
+            modifier = Modifier.height(1.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
         LargeButton(
             onClick = onButtonClick,
             text = NEXT_BUTTON_TEXT,

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/PhoneNumberAuthenticationScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/PhoneNumberAuthenticationScreen.kt
@@ -20,6 +20,8 @@ import com.sopt.withsuhyeon.core.component.button.BasicButtonForTextField
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
 import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
+import com.sopt.withsuhyeon.core.util.KeyStorage.AFTER_SEND_BUTTON_TEXT
+import com.sopt.withsuhyeon.core.util.KeyStorage.BEFORE_SEND_BUTTON_TEXT
 import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
 import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
 
@@ -40,14 +42,12 @@ fun PhoneNumberAuthenticationScreen(
 ) {
     var phoneNumberValue by remember { mutableStateOf("") }
     var isPhoneNumberInputValid by remember { mutableStateOf(false) }
-    var isPhoneNumberInputEnabled by remember { mutableStateOf(true) }
     var isPhoneNumberInputFocused by remember { mutableStateOf(false) }
     var isPhoneNumberAuthVisible by remember { mutableStateOf(false) }
     var isPhoneNumberAuthButtonEnabled by remember { mutableStateOf(false) }
-    var phoneNumberAuthButtonText by remember { mutableStateOf("인증요청") }
+    var phoneNumberAuthButtonText by remember { mutableStateOf(BEFORE_SEND_BUTTON_TEXT) }
     var authNumberValue by remember { mutableStateOf("") }
     var isAuthNumberInputValid by remember { mutableStateOf(false) }
-    var isAuthNumberInputEnabled by remember { mutableStateOf(true) }
     var isAuthNumberInputFocused by remember { mutableStateOf(false) }
 
     Column(
@@ -69,7 +69,6 @@ fun PhoneNumberAuthenticationScreen(
             title = stringResource(R.string.onboarding_phone_number_input_title),
             hint = stringResource(R.string.onboarding_phone_number_input_hint),
             isValid = isPhoneNumberInputValid,
-            enabled = isPhoneNumberInputEnabled,
             onFocusChange = {
                 isPhoneNumberInputFocused = it
             },
@@ -86,7 +85,7 @@ fun PhoneNumberAuthenticationScreen(
                     onClick = {
                         isPhoneNumberAuthVisible = true
                         isPhoneNumberAuthButtonEnabled = false
-                        phoneNumberAuthButtonText = "전송완료"
+                        phoneNumberAuthButtonText = AFTER_SEND_BUTTON_TEXT
                     },
                     modifier = Modifier,
                     enabled = isPhoneNumberAuthButtonEnabled
@@ -102,7 +101,6 @@ fun PhoneNumberAuthenticationScreen(
                 title = stringResource(R.string.onboarding_phone_number_auth_input_title),
                 hint = stringResource(R.string.onboarding_phone_number_auth_input_hint),
                 isValid = isAuthNumberInputValid,
-                enabled = isAuthNumberInputEnabled,
                 onFocusChange = {
                     isAuthNumberInputFocused = it
                 },

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/PhoneNumberAuthenticationScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/PhoneNumberAuthenticationScreen.kt
@@ -1,0 +1,124 @@
+package com.sopt.withsuhyeon.feature.onboarding
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.component.button.BasicButtonForTextField
+import com.sopt.withsuhyeon.core.component.button.LargeButton
+import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
+import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
+import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
+import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
+
+@Composable
+fun PhoneNumberAuthenticationRoute(
+    navigateToNext: () -> Unit,
+    viewModel: OnBoardingViewModel = hiltViewModel()
+) {
+    PhoneNumberAuthenticationScreen(
+        onButtonClick = navigateToNext
+    )
+}
+
+@Composable
+fun PhoneNumberAuthenticationScreen(
+    onButtonClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var phoneNumberValue by remember { mutableStateOf("") }
+    var isPhoneNumberInputValid by remember { mutableStateOf(false) }
+    var isPhoneNumberInputEnabled by remember { mutableStateOf(true) }
+    var isPhoneNumberInputFocused by remember { mutableStateOf(false) }
+    var isPhoneNumberAuthVisible by remember { mutableStateOf(false) }
+    var isPhoneNumberAuthButtonEnabled by remember { mutableStateOf(false) }
+    var phoneNumberAuthButtonText by remember { mutableStateOf("인증요청") }
+    var authNumberValue by remember { mutableStateOf("") }
+    var isAuthNumberInputValid by remember { mutableStateOf(false) }
+    var isAuthNumberInputEnabled by remember { mutableStateOf(true) }
+    var isAuthNumberInputFocused by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+            .fillMaxHeight(),
+    ) {
+        AnimatedProgressBar(progress = 0.33f)
+        Spacer(
+            modifier = Modifier.height(16.dp)
+        )
+        OnBoardingTitle(text = stringResource(R.string.onboarding_phone_number_title))
+        Spacer(
+            modifier = Modifier.height(32.dp)
+        )
+        BasicShortTextField(
+            value = phoneNumberValue,
+            title = stringResource(R.string.onboarding_phone_number_input_title),
+            hint = stringResource(R.string.onboarding_phone_number_input_hint),
+            isValid = isPhoneNumberInputValid,
+            enabled = isPhoneNumberInputEnabled,
+            onFocusChange = {
+                isPhoneNumberInputFocused = it
+            },
+            onValueChange = { input ->
+                isPhoneNumberInputValid = input.length == 11
+                isPhoneNumberAuthButtonEnabled = input.length == 11
+                phoneNumberValue = input
+            },
+            maxLength = 11,
+            errorMessage = stringResource(R.string.onboarding_phone_number_duplication_error_message),
+            trailingContent = {
+                BasicButtonForTextField(
+                    text = phoneNumberAuthButtonText,
+                    onClick = {
+                        isPhoneNumberAuthVisible = true
+                        isPhoneNumberAuthButtonEnabled = false
+                        phoneNumberAuthButtonText = "전송완료"
+                    },
+                    modifier = Modifier,
+                    enabled = isPhoneNumberAuthButtonEnabled
+                )
+            }
+        )
+        Spacer(
+            modifier = Modifier.height(12.dp)
+        )
+        if (isPhoneNumberAuthVisible) {
+            BasicShortTextField(
+                value = authNumberValue,
+                title = stringResource(R.string.onboarding_phone_number_auth_input_title),
+                hint = stringResource(R.string.onboarding_phone_number_auth_input_hint),
+                isValid = isAuthNumberInputValid,
+                enabled = isAuthNumberInputEnabled,
+                onFocusChange = {
+                    isAuthNumberInputFocused = it
+                },
+                onValueChange = { input ->
+                    isAuthNumberInputValid = input.length == 6
+                    authNumberValue = input
+                },
+                maxLength = 6,
+                errorMessage = stringResource(R.string.onboarding_phone_number_duplication_error_message),
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        LargeButton(
+            onClick = onButtonClick,
+            text = NEXT_BUTTON_TEXT,
+            isDisabled = !isAuthNumberInputValid
+        )
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
@@ -1,0 +1,192 @@
+package com.sopt.withsuhyeon.feature.onboarding
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.component.button.LargeButton
+import com.sopt.withsuhyeon.core.component.button.ShowButton
+import com.sopt.withsuhyeon.core.component.checkbox.CheckBox
+import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
+import com.sopt.withsuhyeon.core.util.KeyStorage.CHECKED
+import com.sopt.withsuhyeon.core.util.KeyStorage.DEFAULT
+import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
+import com.sopt.withsuhyeon.core.util.KeyStorage.SECONDARY_TYPE
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
+
+@Composable
+fun TermsOfUseRoute(
+    padding: PaddingValues,
+    navigateToNext: () -> Unit,
+    viewModel: OnBoardingViewModel = hiltViewModel()
+) {
+    TermsOfUseScreen(
+        padding = padding,
+        onButtonClick = {
+            navigateToNext()
+        }
+    )
+}
+
+@Composable
+fun TermsOfUseScreen(
+    padding: PaddingValues,
+    onButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+
+    ) {
+    var isAllTermsSelected by remember { mutableStateOf(false) }
+    var isAgedSelected by remember { mutableStateOf(false) }
+    var isTermsSelected by remember { mutableStateOf(false) }
+    var isPersonalInformationSelected by remember { mutableStateOf(false) }
+
+    fun updateAllTermsSelectedState() {
+        isAllTermsSelected = isAgedSelected && isTermsSelected && isPersonalInformationSelected
+    }
+
+    Column(
+        modifier = modifier
+            .padding(
+                vertical = 20.dp,
+                horizontal = 16.dp
+            )
+            .fillMaxWidth()
+            .fillMaxHeight()
+    ) {
+        AnimatedProgressBar(progress = 0.1f)
+        Spacer(
+            modifier = Modifier.height(16.dp)
+        )
+        Text(
+            text = stringResource(R.string.onboarding_temrs_of_use_title),
+            style = typography.title02_B,
+        )
+        Spacer(
+            modifier = Modifier.height(32.dp)
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CheckBox(
+                placeholder = stringResource(R.string.onboarding_temrs_of_use_all_agree),
+                onClick = {
+                    isAllTermsSelected = !isAllTermsSelected
+                    if (isAllTermsSelected) {
+                        isAgedSelected = true
+                        isTermsSelected = true
+                        isPersonalInformationSelected = true
+                    } else {
+                        isAgedSelected = false
+                        isTermsSelected = false
+                        isPersonalInformationSelected = false
+                    }
+                },
+                state = if (isAllTermsSelected) CHECKED else DEFAULT
+            )
+        }
+
+        Spacer(
+            modifier = Modifier.height(16.dp)
+        )
+        Column(
+            modifier = Modifier
+                .border(
+                    width = 1.dp, color = colors.Grey100, RoundedCornerShape(size = 24.dp)
+                )
+                .padding(
+                    horizontal = 20.dp,
+                    vertical = 24.dp
+                ),
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
+            ) {
+                CheckBox(
+                    placeholder = stringResource(R.string.onboarding_terms_of_use_age),
+                    onClick = {
+                        isAgedSelected = !isAgedSelected
+                        updateAllTermsSelectedState()
+                    },
+                    type = SECONDARY_TYPE,
+                    state = if (isAgedSelected) CHECKED else DEFAULT
+                )
+                ShowButton(onClick = {
+                    // TODO - 정책 연결
+                })
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
+            ) {
+                CheckBox(
+                    placeholder = stringResource(R.string.onboarding_terms_of_use_agree),
+                    onClick = {
+                        isTermsSelected = !isTermsSelected
+                        updateAllTermsSelectedState()
+                    },
+                    type = SECONDARY_TYPE,
+                    state = if (isTermsSelected) CHECKED else DEFAULT
+                )
+                ShowButton(onClick = {
+                    // TODO - 정책 연결
+                })
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
+            ) {
+                CheckBox(
+                    placeholder = stringResource(R.string.onboarding_temrs_of_use_personal_information),
+                    onClick = {
+                        isPersonalInformationSelected = !isPersonalInformationSelected
+                        updateAllTermsSelectedState()
+
+                    },
+                    type = SECONDARY_TYPE,
+                    state = if (isPersonalInformationSelected) CHECKED else DEFAULT
+                )
+                ShowButton(onClick = {
+                    // TODO - 정책 연결
+                })
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        HorizontalDivider(
+            modifier = Modifier.height(1.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        LargeButton(
+            onClick = {
+                // TODO - Navigate 시키기
+            },
+            text = NEXT_BUTTON_TEXT,
+            isDisabled = !isAllTermsSelected,
+        )
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
@@ -3,7 +3,6 @@ package com.sopt.withsuhyeon.feature.onboarding
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,17 +30,15 @@ import com.sopt.withsuhyeon.core.util.KeyStorage.CHECKED
 import com.sopt.withsuhyeon.core.util.KeyStorage.DEFAULT
 import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
 import com.sopt.withsuhyeon.core.util.KeyStorage.SECONDARY_TYPE
+import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
-import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
 @Composable
 fun TermsOfUseRoute(
-    padding: PaddingValues,
     navigateToNext: () -> Unit,
     viewModel: OnBoardingViewModel = hiltViewModel()
 ) {
     TermsOfUseScreen(
-        padding = padding,
         onButtonClick = {
             navigateToNext()
         }
@@ -51,7 +47,6 @@ fun TermsOfUseRoute(
 
 @Composable
 fun TermsOfUseScreen(
-    padding: PaddingValues,
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 
@@ -78,10 +73,7 @@ fun TermsOfUseScreen(
         Spacer(
             modifier = Modifier.height(16.dp)
         )
-        Text(
-            text = stringResource(R.string.onboarding_temrs_of_use_title),
-            style = typography.title02_B,
-        )
+        OnBoardingTitle(stringResource(R.string.onboarding_temrs_of_use_title),)
         Spacer(
             modifier = Modifier.height(32.dp)
         )
@@ -183,7 +175,9 @@ fun TermsOfUseScreen(
         Spacer(modifier = Modifier.height(16.dp))
         LargeButton(
             onClick = {
-                // TODO - Navigate 시키기
+                if (isAllTermsSelected) {
+                    onButtonClick()
+                }
             },
             text = NEXT_BUTTON_TEXT,
             isDisabled = !isAllTermsSelected,

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
@@ -2,6 +2,7 @@ package com.sopt.withsuhyeon.feature.onboarding
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,6 +27,8 @@ import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.button.ShowButton
 import com.sopt.withsuhyeon.core.component.checkbox.CheckBox
 import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
+import com.sopt.withsuhyeon.core.component.topbar.MainTopNavBar
+import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
 import com.sopt.withsuhyeon.core.util.KeyStorage.CHECKED
 import com.sopt.withsuhyeon.core.util.KeyStorage.DEFAULT
 import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
@@ -59,7 +62,11 @@ fun TermsOfUseScreen(
     fun updateAllTermsSelectedState() {
         isAllTermsSelected = isAgedSelected && isTermsSelected && isPersonalInformationSelected
     }
-
+    Box() {
+        MainTopNavBar(
+            text = ""
+        )
+    }
     Column(
         modifier = modifier
             .padding(

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/TermsOfUseScreen.kt
@@ -1,12 +1,12 @@
 package com.sopt.withsuhyeon.feature.onboarding
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -28,9 +28,9 @@ import com.sopt.withsuhyeon.core.component.button.ShowButton
 import com.sopt.withsuhyeon.core.component.checkbox.CheckBox
 import com.sopt.withsuhyeon.core.component.progressbar.AnimatedProgressBar
 import com.sopt.withsuhyeon.core.component.topbar.MainTopNavBar
-import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
 import com.sopt.withsuhyeon.core.util.KeyStorage.CHECKED
 import com.sopt.withsuhyeon.core.util.KeyStorage.DEFAULT
+import com.sopt.withsuhyeon.core.util.KeyStorage.EMPTY_STRING
 import com.sopt.withsuhyeon.core.util.KeyStorage.NEXT_BUTTON_TEXT
 import com.sopt.withsuhyeon.core.util.KeyStorage.SECONDARY_TYPE
 import com.sopt.withsuhyeon.feature.onboarding.components.OnBoardingTitle
@@ -62,25 +62,25 @@ fun TermsOfUseScreen(
     fun updateAllTermsSelectedState() {
         isAllTermsSelected = isAgedSelected && isTermsSelected && isPersonalInformationSelected
     }
-    Box() {
-        MainTopNavBar(
-            text = ""
-        )
-    }
     Column(
         modifier = modifier
+            .background(color = colors.White)
             .padding(
-                vertical = 20.dp,
+                vertical = 16.dp,
                 horizontal = 16.dp
             )
-            .fillMaxWidth()
-            .fillMaxHeight()
+            .fillMaxSize()
+
     ) {
+        MainTopNavBar(
+            text = EMPTY_STRING,
+            modifier = Modifier.padding(20.dp)
+        )
         AnimatedProgressBar(progress = 0.1f)
         Spacer(
             modifier = Modifier.height(16.dp)
         )
-        OnBoardingTitle(stringResource(R.string.onboarding_temrs_of_use_title),)
+        OnBoardingTitle(stringResource(R.string.onboarding_temrs_of_use_title))
         Spacer(
             modifier = Modifier.height(32.dp)
         )

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/components/OnBoardingTitle.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/components/OnBoardingTitle.kt
@@ -1,0 +1,20 @@
+package com.sopt.withsuhyeon.feature.onboarding.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
+
+@Composable
+fun OnBoardingTitle(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        modifier = modifier.padding(vertical = 20.dp),
+        text = text,
+        style = typography.title02_B,
+    )
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/navigation/OnBoardingNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/navigation/OnBoardingNavigation.kt
@@ -1,24 +1,37 @@
 package com.sopt.withsuhyeon.feature.onboarding.navigation
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.sopt.withsuhyeon.feature.onboarding.PhoneNumberAuthenticationRoute
 import com.sopt.withsuhyeon.feature.onboarding.TermsOfUseRoute
 import com.sopt.withsuhyeon.core.navigation.Route.TermsOfUse as TermsOfUseRoute
+import com.sopt.withsuhyeon.core.navigation.Route.PhoneNumberAuth as PhoneNumberAuthRoute
+import com.sopt.withsuhyeon.core.navigation.Route.NickNameAuth as NickNameAuthRoute
 
 fun NavController.navigateToTermsOfUse() {
     navigate(TermsOfUseRoute)
 }
+fun NavController.navigateToPhoneNumberAuth() {
+    navigate(PhoneNumberAuthRoute)
+}
 
-fun NavGraphBuilder.termsOfUseNavGraph(
-    padding: PaddingValues,
-    onNavigateToNext: () -> Unit
+fun NavController.navigateToNickNameAuth() {
+    navigate(NickNameAuthRoute)
+}
+
+fun NavGraphBuilder.onBoardingNavGraph(
+    onNavigateToPhoneNumberAuth: () -> Unit,
+    onNavigateToNickNameAuth: () -> Unit
 ) {
     composable<TermsOfUseRoute> {
         TermsOfUseRoute(
-            padding = padding,
-            navigateToNext = onNavigateToNext
+            navigateToNext = onNavigateToPhoneNumberAuth
+        )
+    }
+    composable<PhoneNumberAuthRoute> {
+        PhoneNumberAuthenticationRoute(
+            navigateToNext = onNavigateToNickNameAuth
         )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/navigation/OnBoardingNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/navigation/OnBoardingNavigation.kt
@@ -4,21 +4,21 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.sopt.withsuhyeon.feature.onboarding.OnBoardingRoute
-import com.sopt.withsuhyeon.core.navigation.Route.OnBoarding as OnBoardingRoute
+import com.sopt.withsuhyeon.feature.onboarding.TermsOfUseRoute
+import com.sopt.withsuhyeon.core.navigation.Route.TermsOfUse as TermsOfUseRoute
 
-fun NavController.navigateToOnBoarding() {
-    navigate(OnBoardingRoute)
+fun NavController.navigateToTermsOfUse() {
+    navigate(TermsOfUseRoute)
 }
 
-fun NavGraphBuilder.onBoardingNavGraph(
+fun NavGraphBuilder.termsOfUseNavGraph(
     padding: PaddingValues,
-    onNavigateToHome: () -> Unit
+    onNavigateToNext: () -> Unit
 ) {
-    composable<OnBoardingRoute> {
-        OnBoardingRoute(
+    composable<TermsOfUseRoute> {
+        TermsOfUseRoute(
             padding = padding,
-            navigateToHome = onNavigateToHome
+            navigateToNext = onNavigateToNext
         )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/navigation/OnBoardingNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/navigation/OnBoardingNavigation.kt
@@ -3,6 +3,8 @@ package com.sopt.withsuhyeon.feature.onboarding.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.sopt.withsuhyeon.core.navigation.Route
+import com.sopt.withsuhyeon.feature.onboarding.NickNameAuthenticationRoute
 import com.sopt.withsuhyeon.feature.onboarding.PhoneNumberAuthenticationRoute
 import com.sopt.withsuhyeon.feature.onboarding.TermsOfUseRoute
 import com.sopt.withsuhyeon.core.navigation.Route.TermsOfUse as TermsOfUseRoute
@@ -12,6 +14,7 @@ import com.sopt.withsuhyeon.core.navigation.Route.NickNameAuth as NickNameAuthRo
 fun NavController.navigateToTermsOfUse() {
     navigate(TermsOfUseRoute)
 }
+
 fun NavController.navigateToPhoneNumberAuth() {
     navigate(PhoneNumberAuthRoute)
 }
@@ -20,9 +23,14 @@ fun NavController.navigateToNickNameAuth() {
     navigate(NickNameAuthRoute)
 }
 
+fun NavController.navigateToSelectYearOfBirth() {
+    navigate(Route.SelectYearOfBirth)
+}
+
 fun NavGraphBuilder.onBoardingNavGraph(
     onNavigateToPhoneNumberAuth: () -> Unit,
-    onNavigateToNickNameAuth: () -> Unit
+    onNavigateToNickNameAuth: () -> Unit,
+    onNavigateToSelectYearOfBirth: () -> Unit
 ) {
     composable<TermsOfUseRoute> {
         TermsOfUseRoute(
@@ -32,6 +40,11 @@ fun NavGraphBuilder.onBoardingNavGraph(
     composable<PhoneNumberAuthRoute> {
         PhoneNumberAuthenticationRoute(
             navigateToNext = onNavigateToNickNameAuth
+        )
+    }
+    composable<NickNameAuthRoute> {
+        NickNameAuthenticationRoute(
+            navigateToNext = onNavigateToSelectYearOfBirth
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,5 +84,4 @@
     <string name="onboarding_nickname_screen_title">수현이랑에서 사용할\n닉네임을 입력해주세요</string>
     <string name="onboarding_nickname_input_title">닉네임</string>
     <string name="onboarding_nickname_input_hint">한글, 영문, 숫자로 조합된 2~12자</string>
-    <string name="onboarding_nickname_max_input_error_message">최대 12글자 이하로 입력해주세요</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,11 @@
     <string name="block_bottomsheet_sub_title">차단하고자하는 전화번호를 입력해주시면,\n앱내에서 숨기기 처리됩니다.</string>
     <string name="block_bottomsheet_button_text">차단하러 가기</string>
     <string name="block_bottomsheet_skip_text">괜찮아요</string>
+
+    <!-- 수현이랑 온보딩 플로우 String 모음-->
+    <string name="onboarding_temrs_of_use_title">수현이랑\n서비스 이용약관</string>
+    <string name="onboarding_temrs_of_use_all_agree">모두 동의</string>
+    <string name="onboarding_terms_of_use_age">[필수] 만 18세 이상</string>
+    <string name="onboarding_terms_of_use_agree">[필수] 이용약관 동의</string>
+    <string name="onboarding_temrs_of_use_personal_information">[필수] 개인정보 처리방침 동의</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,4 +109,5 @@
     <string name="alert_modal_delete_post_description">한번 삭제된 게시물은\n다시 복구할 수 없습니다.</string>
     <string name="alert_modal_delete_btn">삭제하기</string>
     <string name="alert_modal_cancel_btn">취소하기</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,6 @@
     <string name="block_bottomsheet_button_text">차단하러 가기</string>
     <string name="block_bottomsheet_skip_text">괜찮아요</string>
 
-<<<<<<< HEAD
     <!-- 수현이랑 온보딩 플로우 String 모음-->
     <string name="onboarding_temrs_of_use_title">수현이랑\n서비스 이용약관</string>
     <string name="onboarding_temrs_of_use_all_agree">모두 동의</string>
@@ -89,7 +88,6 @@
     <string name="onboarding_nickname_screen_title">수현이랑에서 사용할\n닉네임을 입력해주세요</string>
     <string name="onboarding_nickname_input_title">닉네임</string>
     <string name="onboarding_nickname_input_hint">한글, 영문, 숫자로 조합된 2~12자</string>
-=======
     <!-- 공통 컴포넌트 - Top Nav Bar -->
     <string name="top_nav_bar_btn_icon_description">Top Nav Bar Btn Icon</string>
 
@@ -111,5 +109,4 @@
     <string name="alert_modal_delete_post_description">한번 삭제된 게시물은\n다시 복구할 수 없습니다.</string>
     <string name="alert_modal_delete_btn">삭제하기</string>
     <string name="alert_modal_cancel_btn">취소하기</string>
->>>>>>> 9d67d1615c0ed3d1b57216a247ead3e06f471d1c
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,4 +75,10 @@
     <string name="onboarding_terms_of_use_age">[필수] 만 18세 이상</string>
     <string name="onboarding_terms_of_use_agree">[필수] 이용약관 동의</string>
     <string name="onboarding_temrs_of_use_personal_information">[필수] 개인정보 처리방침 동의</string>
+    <string name="onboarding_phone_number_title">본인인증을 위한\n휴대폰 번호 인증이 필요해요</string>
+    <string name="onboarding_phone_number_duplication_error_message">이미 가입된 번호입니다</string>
+    <string name="onboarding_phone_number_input_title">휴대폰 번호</string>
+    <string name="onboarding_phone_number_input_hint"> - 를 제외한 휴대폰 번호를 입력해주세요</string>
+    <string name="onboarding_phone_number_auth_input_title">인증 번호 (6자리)</string>
+    <string name="onboarding_phone_number_auth_input_hint">인증번호 6자리</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,8 @@
     <string name="onboarding_phone_number_input_hint"> - 를 제외한 휴대폰 번호를 입력해주세요</string>
     <string name="onboarding_phone_number_auth_input_title">인증 번호 (6자리)</string>
     <string name="onboarding_phone_number_auth_input_hint">인증번호 6자리</string>
+    <string name="onboarding_nickname_screen_title">수현이랑에서 사용할\n닉네임을 입력해주세요</string>
+    <string name="onboarding_nickname_input_title">닉네임</string>
+    <string name="onboarding_nickname_input_hint">한글, 영문, 숫자로 조합된 2~12자</string>
+    <string name="onboarding_nickname_max_input_error_message">최대 12글자 이하로 입력해주세요</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #33 

## Work Description 📝
회원가입 flow의 1번 SubTask을 진행했습니다.
구체적으로 구현한 내용은 아래와 같습니다.

- 이용약관 뷰
- 휴대폰인증 뷰
- 닉네임 입력 뷰


## Screenshot 📸

https://github.com/user-attachments/assets/a1ca8111-5f69-4fab-b57a-fa77dde5f645


## Uncompleted Tasks 😅
- [ ] 이용약관 연결
- [ ] ViewModel 활용

## To Reviewers 📢
우선 이용약관 뷰는 모든 항목에 대한 동의가 있어야 다음 스크린에 넘어갈 수 있도록 설계 돼, 따로 ViewModel에 저장하지 않았습니다.
추가로 휴대폰 인증 뷰, 닉네임 입력 뷰에서의 ViewModel 활용 로직은 **Issue #36** (SubTask3)에서 작업하여 최종 병합하겠습니다.
마지막으로 @serioushyeon 님의 **PR #15** **AnimatedProgressBar의 padding 값을 삭제**하였습니다. 또 어제 같이 논의한 **BasicShortTextField**의 에러처리 수정사항은 **Issue #35** (SubTask2)에서 수정하여 다음 PR에서 병합하겠습니다. 

1/3 정도 지났습니다!! 끝까지 파이팅해요☺️