### PR TITLE
[FEAT/#30] 이미지 퍼미션 기초 세팅, 갤러리 뷰 및 네비게이션 로직 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <application
         android:name=".WithSuhyeonApplication"

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/bottomsheet/DeletePostBottomSheet.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/bottomsheet/DeletePostBottomSheet.kt
@@ -1,0 +1,59 @@
+package com.sopt.withsuhyeon.core.component.bottomsheet
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.withsuhyeon.core.component.button.DeleteLargeButton
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeletePostBottomSheet(
+    isBottomSheetVisible: Boolean,
+    onDeleteClick: () -> Unit,
+    onCloseClick: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    if (isBottomSheetVisible) {
+        ModalBottomSheet(
+            onDismissRequest = { onDismiss() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = colors.White
+        ) {
+            DeleteLargeButton(
+                text = "삭제하기",
+                modifier = Modifier.padding(horizontal = 16.dp),
+                isDownloadBtn = true,
+                onClick = {
+                    onDeleteClick()
+                }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            DeleteLargeButton(
+                text = "닫기",
+                modifier = Modifier.padding(horizontal = 16.dp),
+                isDownloadBtn = false
+            ) {
+                onCloseClick()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DeletePostBottomSheetPreview() {
+    WithSuhyeonTheme {
+        DeletePostBottomSheet(true, {}, {}) { }
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/bottomsheet/GalleryCategoryBottomSheet.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/bottomsheet/GalleryCategoryBottomSheet.kt
@@ -27,7 +27,7 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 fun GalleryCategoryBottomSheet(
     isVisible: Boolean,
     categories: List<String>,
-    selectedCategories: List<String>,
+    selectedCategory: String,
     onCategoryChipClick: (String) -> Unit,
     onConfirmClick: () -> Unit,
     onDismiss: () -> Unit
@@ -57,7 +57,7 @@ fun GalleryCategoryBottomSheet(
                     categories.forEach { category ->
                         CategoryChip(
                             text = category,
-                            isSelected = selectedCategories.contains(category),
+                            isSelected = selectedCategory.contains(category),
                             onClick = { onCategoryChipClick(category) }
                         )
                     }
@@ -67,7 +67,7 @@ fun GalleryCategoryBottomSheet(
 
                 LargeButton(
                     text = stringResource(R.string.gallery_category_bottom_sheet_confirm_btn),
-                    isDisabled = selectedCategories.isEmpty(),
+                    isDisabled = selectedCategory.isEmpty(),
                     onClick = { onConfirmClick() }
                 )
             }

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/button/DeleteLargeButton.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/button/DeleteLargeButton.kt
@@ -16,7 +16,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -66,7 +67,7 @@ fun DeleteLargeButton(
         ) {
             if (isDownloadBtn) {
                 Icon(
-                    painter = painterResource(id = R.drawable.ic_delete),
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_delete),
                     contentDescription = null,
                     tint = textColor,
                     modifier = Modifier

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/button/DeleteLargeButton.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/button/DeleteLargeButton.kt
@@ -1,0 +1,112 @@
+package com.sopt.withsuhyeon.core.component.button
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.util.modifier.noRippleClickable
+import com.sopt.withsuhyeon.ui.theme.White
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
+
+@Composable
+fun DeleteLargeButton(
+    text: String,
+    isDownloadBtn: Boolean = true,
+    modifier: Modifier = Modifier,
+    font: TextStyle = typography.body01_B,
+    onClick: () -> Unit,
+) {
+    val backgroundColor: Color
+    val textColor: Color
+
+    when (isDownloadBtn) {
+        true -> {
+            backgroundColor = colors.Grey50
+            textColor = colors.Red01
+        }
+
+        else -> {
+            backgroundColor = colors.Grey50
+            textColor = colors.Grey500
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .background(backgroundColor, shape = RoundedCornerShape(size = 16.dp))
+            .padding(horizontal = 16.dp)
+            .noRippleClickable(onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            if (isDownloadBtn) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_delete),
+                    contentDescription = null,
+                    tint = textColor,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .padding(end = 8.dp)
+                )
+            }
+            Text(
+                text = text,
+                color = textColor,
+                textAlign = TextAlign.Center,
+                style = font
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DeleteLargeButtonPreview(
+    modifier: Modifier = Modifier
+) {
+    WithSuhyeonTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .background(White)
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            DeleteLargeButton(
+                text = "버튼",
+                onClick = {}
+            )
+            DeleteLargeButton(
+                text = "닫기",
+                onClick = {},
+                isDownloadBtn = false
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/button/SmallButton.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/button/SmallButton.kt
@@ -57,7 +57,7 @@ fun SmallButton(
     }
     Box(
         modifier = modifier
-            .width(160.dp)
+            .fillMaxWidth()
             .background(
                 backgroundColor,
                 shape = RoundedCornerShape(size = 16.dp)

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/card/GalleryMainCardItem.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/card/GalleryMainCardItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.sopt.withsuhyeon.core.util.modifier.noRippleClickable
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
@@ -22,10 +23,12 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 fun GalleryMainCardItem(
     text: String,
     image: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .noRippleClickable { onClick() },
         horizontalAlignment = Alignment.Start
     ) {
         AsyncImage(
@@ -51,6 +54,6 @@ fun GalleryMainCardItem(
 @Composable
 private fun GalleryMainCardItemPreview() {
     WithSuhyeonTheme {
-        GalleryMainCardItem("술자리 사진 모음집", "")
+        GalleryMainCardItem("술자리 사진 모음집", "https://via.placeholder.com/150", {})
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/floatingbutton/AnimatedAddPostButton.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/floatingbutton/AnimatedAddPostButton.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.util.modifier.noRippleClickable
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
@@ -44,7 +45,7 @@ fun AnimatedAddPostButton(
     )
 
     FloatingActionButton(
-        onClick = onClick,
+        onClick = { onClick() },
         modifier = modifier
             .height(48.dp)
             .width(floatingButtonWidth),

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/modal/AlertModal.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/modal/AlertModal.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.sopt.withsuhyeon.R
 import com.sopt.withsuhyeon.core.component.button.SmallButton
+import com.sopt.withsuhyeon.core.util.KeyStorage.ALERT_TYPE
+import com.sopt.withsuhyeon.core.util.KeyStorage.DISABLED_TYPE
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
@@ -64,7 +66,7 @@ fun AlertModal(
                 ) {
                     SmallButton(
                         text = stringResource(R.string.alert_modal_cancel_btn),
-                        type = "disabled",
+                        type = DISABLED_TYPE,
                         modifier = Modifier.weight(1f)
                     ) {
                         onCancelClick()
@@ -72,7 +74,7 @@ fun AlertModal(
 
                     SmallButton(
                         text = stringResource(R.string.alert_modal_delete_btn),
-                        type = "alert",
+                        type = ALERT_TYPE,
                         modifier = Modifier.weight(1f)
                     ) {
                         onDeleteClick()

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/modal/AlertModal.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/modal/AlertModal.kt
@@ -25,12 +25,12 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
 @Composable
 fun AlertModal(
-    onDelete: () -> Unit,
-    onCancel: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onCancelClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Dialog(
-        onDismissRequest = onCancel
+        onDismissRequest = onCancelClick
     ) {
         Surface(
             shape = RoundedCornerShape(24.dp),
@@ -67,7 +67,7 @@ fun AlertModal(
                         type = "disabled",
                         modifier = Modifier.weight(1f)
                     ) {
-                        onCancel()
+                        onCancelClick()
                     }
 
                     SmallButton(
@@ -75,7 +75,7 @@ fun AlertModal(
                         type = "alert",
                         modifier = Modifier.weight(1f)
                     ) {
-                        onDelete()
+                        onDeleteClick()
                     }
                 }
             }
@@ -83,7 +83,7 @@ fun AlertModal(
     }
 }
 
-@Preview (showBackground = true)
+@Preview(showBackground = true)
 @Composable
 private fun AlertModalPreview() {
     WithSuhyeonTheme {

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/BasicShortTextField.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/BasicShortTextField.kt
@@ -63,6 +63,7 @@ fun BasicShortTextField(
             isMaxLengthExceeded -> colors.Red01
             isFocused -> colors.Purple300
             value.isNotEmpty() && enabled && !isValid -> colors.Red01
+            !isValid -> colors.Red01
             else -> colors.Grey100
         }
     val textColor = if (enabled) colors.Grey900 else colors.Grey300

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/LongTextField.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/LongTextField.kt
@@ -33,6 +33,7 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 @Composable
 fun LongTextField(
     value: String,
+    hint: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     maxLength: Int = LONG_TEXTFIELD_MAX_LENGTH,
@@ -61,6 +62,13 @@ fun LongTextField(
                     isError = true
                     onValueChange(input.substring(0, maxLength))
                 }
+            },
+            placeholder = {
+                Text(
+                    text = hint,
+                    style = typography.body03_R,
+                    color = colors.Grey400
+                )
             },
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/LongTextField.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/textfield/LongTextField.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -21,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color.Companion.Transparent
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.sopt.withsuhyeon.R
 import com.sopt.withsuhyeon.core.util.KeyStorage.LONG_TEXTFIELD_MAX_LENGTH
@@ -32,7 +35,10 @@ fun LongTextField(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    maxLength: Int = LONG_TEXTFIELD_MAX_LENGTH
+    maxLength: Int = LONG_TEXTFIELD_MAX_LENGTH,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
 ) {
     var isFocused by remember { mutableStateOf(false) }
     var isError by remember { mutableStateOf(false) }
@@ -73,7 +79,10 @@ fun LongTextField(
                 unfocusedContainerColor = Transparent,
                 focusedIndicatorColor = Transparent,
                 unfocusedIndicatorColor = Transparent
-            )
+            ),
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            visualTransformation = visualTransformation
         )
 
         Row(

--- a/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.Serializable
 sealed interface Route {
     @Serializable
     data object OnBoarding : Route
+    @Serializable
+    data object GalleryUpload : Route
 }
 
 sealed interface MainTabRoute : Route {

--- a/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
@@ -7,6 +7,8 @@ sealed interface Route {
     data object OnBoarding : Route
     @Serializable
     data object GalleryUpload : Route
+    @Serializable
+    data object GalleryPostDetail : Route
 }
 
 sealed interface MainTabRoute : Route {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -17,14 +17,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.component.bottomsheet.DeletePostBottomSheet
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.chip.MediumChip
+import com.sopt.withsuhyeon.core.component.modal.AlertModal
 import com.sopt.withsuhyeon.core.component.profile.PostProfileInfoRow
 import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
 import com.sopt.withsuhyeon.core.type.MediumChipType
@@ -34,16 +37,21 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
 @Composable
 fun GalleryPostDetailRoute(
-    padding: PaddingValues
+    padding: PaddingValues,
+    popBackStackToGallery: () -> Unit
 ) {
     GalleryPostDetailScreen(
-        padding = padding
+        padding = padding,
+        onDownloadBtnClick = {
+            popBackStackToGallery()
+        }
     )
 }
 
 @Composable
 fun GalleryPostDetailScreen(
     padding: PaddingValues,
+    onDownloadBtnClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val category by remember { mutableStateOf("") }
@@ -53,6 +61,37 @@ fun GalleryPostDetailScreen(
     val date by remember { mutableStateOf("") }
     val galleryPostContent by remember { mutableStateOf("") }
 
+    var isDeleteBottomSheetVisible by remember { mutableStateOf(false) }
+    var isDeleteAlertModalVisible by remember { mutableStateOf (false) }
+
+    if (isDeleteBottomSheetVisible) {
+        DeletePostBottomSheet(
+            isBottomSheetVisible = isDeleteBottomSheetVisible,
+            onDeleteClick = {
+                isDeleteBottomSheetVisible = false
+                isDeleteAlertModalVisible = true
+            },
+            onCloseClick = {
+                isDeleteBottomSheetVisible = false
+            },
+            onDismiss = {
+                isDeleteBottomSheetVisible = false
+            }
+        )
+    }
+
+    if (isDeleteAlertModalVisible) {
+        AlertModal(
+            onDeleteClick = {
+                isDeleteAlertModalVisible = false
+                onDownloadBtnClick()
+            },
+            onCancelClick = {
+                isDeleteAlertModalVisible = false
+            }
+        )
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -61,10 +100,12 @@ fun GalleryPostDetailScreen(
     ) {
         SubTopNavBar(
             text = "",
-            btnIcon = painterResource(R.drawable.ic_close),
+            btnIcon = painterResource(R.drawable.ic_menu),
             isTextVisible = true,
             isBtnVisible = true,
-            onCloseBtnClicked = {},
+            onCloseBtnClicked = {
+                isDeleteBottomSheetVisible = true
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .background(colors.White)
@@ -131,7 +172,7 @@ fun GalleryPostDetailScreen(
         ) {
             LargeButton(
                 text = "다운로드",
-                onClick = {},
+                onClick = onDownloadBtnClick,
                 isDownloadBtn = true,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sopt.withsuhyeon.R
@@ -99,7 +101,7 @@ fun GalleryPostDetailScreen(
             .background(colors.White)
     ) {
         SubTopNavBar(
-            text = "",
+            text = stringResource(R.string.blank),
             btnIcon = painterResource(R.drawable.ic_menu),
             isTextVisible = true,
             isBtnVisible = true,
@@ -150,6 +152,14 @@ fun GalleryPostDetailScreen(
                 userName = userName,
                 date = date,
                 views = "00"
+            )
+
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = colors.Grey100,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp)
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -1,0 +1,150 @@
+package com.sopt.withsuhyeon.feature.gallery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.component.button.LargeButton
+import com.sopt.withsuhyeon.core.component.chip.MediumChip
+import com.sopt.withsuhyeon.core.component.profile.PostProfileInfoRow
+import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
+import com.sopt.withsuhyeon.core.type.MediumChipType
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
+
+@Composable
+fun GalleryPostDetailRoute(
+    padding: PaddingValues
+) {
+    GalleryPostDetailScreen(
+        padding = padding
+    )
+}
+
+@Composable
+fun GalleryPostDetailScreen(
+    padding: PaddingValues,
+    modifier: Modifier = Modifier
+) {
+    val category by remember { mutableStateOf("") }
+    val galleryPostTitle by remember { mutableStateOf("") }
+    val profileImage by remember { mutableStateOf("") }
+    val userName by remember { mutableStateOf("") }
+    val date by remember { mutableStateOf("") }
+    val galleryPostContent by remember { mutableStateOf("") }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .background(colors.White)
+    ) {
+        SubTopNavBar(
+            text = "",
+            btnIcon = painterResource(R.drawable.ic_close),
+            isTextVisible = true,
+            isBtnVisible = true,
+            onCloseBtnClicked = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(colors.White)
+                .align(Alignment.TopCenter)
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 52.dp)
+                .verticalScroll(rememberScrollState())
+                .background(colors.White)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .background(colors.Grey500)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            MediumChip(
+                mediumChipType = MediumChipType.CATEGORY,
+                dynamicString = category,
+                modifier = Modifier.padding(start = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = galleryPostTitle,
+                style = typography.body01_SB,
+                color = colors.Black,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            PostProfileInfoRow(
+                profileImage = profileImage,
+                userName = userName,
+                date = date,
+                views = "00"
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = galleryPostContent,
+                style = typography.body03_R,
+                color = colors.Black,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+            Spacer(modifier = Modifier.height(88.dp))
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(colors.White)
+                .padding(16.dp)
+                .align(Alignment.BottomCenter)
+        ) {
+            LargeButton(
+                text = "다운로드",
+                onClick = {},
+                isDownloadBtn = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun GalleryPostDetailScreenPreview() {
+    WithSuhyeonTheme {
+//        GalleryPostDetailScreen(
+//            "바다", "가평엠티라능", "", "작심이", "1월 1일", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+//        )
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -181,21 +181,11 @@ fun GalleryPostDetailScreen(
                 .align(Alignment.BottomCenter)
         ) {
             LargeButton(
-                text = "다운로드",
+                text = stringResource(R.string.gallery_download_btn),
                 onClick = onDownloadBtnClick,
                 isDownloadBtn = true,
                 modifier = Modifier.fillMaxWidth()
             )
         }
-    }
-}
-
-@Preview
-@Composable
-private fun GalleryPostDetailScreenPreview() {
-    WithSuhyeonTheme {
-//        GalleryPostDetailScreen(
-//            "바다", "가평엠티라능", "", "작심이", "1월 1일", "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
-//        )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -1,7 +1,6 @@
 package com.sopt.withsuhyeon.feature.gallery
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -13,20 +13,25 @@ import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
 import com.sopt.withsuhyeon.core.component.floatingbutton.AddGalleryPostButton
+import com.sopt.withsuhyeon.core.navigation.Route
 
 @Composable
 fun GalleryRoute(
     padding: PaddingValues,
+    navController: NavController,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
     GalleryScreen(
-        padding = padding
+        padding = padding,
+        navController = navController
     )
 }
 @Composable
 private fun GalleryScreen(
-    padding: PaddingValues
+    padding: PaddingValues,
+    navController: NavController
 ) {
     Box(
         modifier = Modifier
@@ -48,7 +53,9 @@ private fun GalleryScreen(
             modifier = Modifier
                 .align(BottomCenter)
                 .padding(bottom = 16.dp),
-            onClick = { }
+            onClick = {
+                navController.navigate(Route.GalleryUpload)
+            }
         )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -42,12 +42,16 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 fun GalleryRoute(
     padding: PaddingValues,
     navigateToGalleryUpload: () -> Unit,
+    navigateToGalleryPostDetail: () -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
     GalleryScreen(
         padding = padding,
         onFloatingButtonClick = {
             navigateToGalleryUpload()
+        },
+        onGalleryCardItemClick = {
+            navigateToGalleryPostDetail()
         }
     )
 }
@@ -56,6 +60,7 @@ fun GalleryRoute(
 private fun GalleryScreen(
     padding: PaddingValues,
     onFloatingButtonClick: () -> Unit,
+    onGalleryCardItemClick: () -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
     val lazyGridState = rememberLazyGridState()
@@ -128,6 +133,7 @@ private fun GalleryScreen(
                     GalleryMainCardItem(
                         text = text,
                         image = image,
+                        onClick = onGalleryCardItemClick,
                         modifier = Modifier
                     )
                 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -1,6 +1,7 @@
 package com.sopt.withsuhyeon.feature.gallery
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -37,26 +38,26 @@ import com.sopt.withsuhyeon.core.component.chip.NewCategoryChip
 import com.sopt.withsuhyeon.core.component.floatingbutton.AnimatedAddPostButton
 import com.sopt.withsuhyeon.core.component.topbar.MainTopNavBar
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
-import androidx.navigation.NavController
-import com.sopt.withsuhyeon.core.component.floatingbutton.AddGalleryPostButton
-import com.sopt.withsuhyeon.core.navigation.Route
 
 @Composable
 fun GalleryRoute(
     padding: PaddingValues,
-    navController: NavController,
+    navigateToGalleryUpload: () -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
     GalleryScreen(
         padding = padding,
-        navController = navController
+        onFloatingButtonClick = {
+            navigateToGalleryUpload()
+        }
     )
 }
 @SuppressLint("UnrememberedMutableState")
 @Composable
 private fun GalleryScreen(
     padding: PaddingValues,
-    navController: NavController
+    onFloatingButtonClick: () -> Unit,
+    viewModel: GalleryViewModel = hiltViewModel()
 ) {
     val lazyGridState = rememberLazyGridState()
 
@@ -140,7 +141,7 @@ private fun GalleryScreen(
             modifier = Modifier
                 .align(BottomEnd)
                 .padding(bottom = 16.dp, end = 16.dp),
-            onClick = { }
+            onClick = onFloatingButtonClick
         )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -1,0 +1,22 @@
+package com.sopt.withsuhyeon.feature.gallery
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun GalleryUploadRoute(
+    padding: PaddingValues,
+    viewModel: GalleryViewModel = hiltViewModel()
+) {
+    GalleryUploadScreen(
+        padding = padding
+    )
+}
+
+@Composable
+private fun GalleryUploadScreen(
+    padding: PaddingValues
+) {
+
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -28,16 +28,12 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 @Composable
 fun GalleryUploadRoute(
     padding: PaddingValues,
-    // image: String,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
+    GalleryUploadScreen(
+        modifier = Modifier.fillMaxSize()
             .padding(padding)
-    ) {
-        GalleryUploadScreen()
-    }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -45,6 +45,9 @@ fun GalleryUploadRoute(
         padding = padding,
         onCompleteBtnClick = {
             popBackStackToGallery()
+        },
+        onCloseBtnClick = {
+            popBackStackToGallery()
         }
     )
 }
@@ -54,6 +57,7 @@ private fun GalleryUploadScreen(
     padding: PaddingValues,
     modifier: Modifier = Modifier,
     onCompleteBtnClick: () -> Unit,
+    onCloseBtnClick: () -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
     var isDeleteBottomSheetVisible by remember { mutableStateOf(false) }
@@ -100,11 +104,11 @@ private fun GalleryUploadScreen(
         ) {
             SubTopNavBar(
                 text = "업로드",
-                btnIcon = painterResource(R.drawable.ic_menu),
+                btnIcon = painterResource(R.drawable.ic_close),
                 isTextVisible = true,
                 isBtnVisible = true,
                 onCloseBtnClicked = {
-                    isDeleteBottomSheetVisible = true
+                    onCloseBtnClick()
                 },
                 modifier = modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -55,6 +55,7 @@ private fun GalleryUploadScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
+            .padding(padding)
             .background(colors.White)
     ) {
         SubTopNavBar(
@@ -72,8 +73,9 @@ private fun GalleryUploadScreen(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(top = 56.dp, bottom = 72.dp, start = 8.dp, end = 8.dp)
-                .verticalScroll(rememberScrollState()),
+                .padding(top = 56.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             var isError by remember { mutableStateOf(false) }
@@ -85,6 +87,7 @@ private fun GalleryUploadScreen(
                 "수영장/빠지", "바다/계곡", "스키장", "찜질방", "캠핑/글램핑",
                 "파티룸", "절/교회 수련회", "해외여행", "공항", "기타"
             )
+            var galleryUploadDescription by remember { mutableStateOf("") }
 
             if (isBottomSheetVisible) {
                 GalleryCategoryBottomSheet(
@@ -168,10 +171,14 @@ private fun GalleryUploadScreen(
             )
 
             LongTextField(
-                value = "",
-                onValueChange = {},
+                value = galleryUploadDescription,
+                onValueChange = { newDescription ->
+                    galleryUploadDescription = newDescription
+                },
                 modifier = modifier.padding(horizontal = 16.dp)
             )
+
+            Spacer(modifier = modifier.height(80.dp))
         }
 
         Box(

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -1,22 +1,138 @@
 package com.sopt.withsuhyeon.feature.gallery
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.sopt.withsuhyeon.core.component.button.LargeButton
+import com.sopt.withsuhyeon.core.component.dropdown.text.TextDropDown
+import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
+import com.sopt.withsuhyeon.core.component.textfield.LongTextField
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 
 @Composable
 fun GalleryUploadRoute(
     padding: PaddingValues,
+    // image: String,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
-    GalleryUploadScreen(
-        padding = padding
-    )
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+    ) {
+        GalleryUploadScreen()
+    }
 }
 
 @Composable
 private fun GalleryUploadScreen(
-    padding: PaddingValues
+    modifier: Modifier = Modifier
 ) {
+    Column(
+        modifier = modifier.fillMaxSize()
+    ) {
+        val value by remember { mutableStateOf("") }
+        var isError by remember { mutableStateOf(false) }
+        var errorMessage by remember { mutableStateOf("") }
 
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                item {
+                    GalleryUploadWithPicker({})
+                }
+
+                item {
+                    TextDropDown(
+                        value = value,
+                        hint = "눌러서 카테고리 선택하기",
+                        isError = isError,
+                        errorMessage = errorMessage,
+                        onClick = {
+                            isError = !isError
+                            if(isError)
+                                errorMessage = "필수로 입력해줘"
+                        }
+                    )
+                }
+
+                item {
+                    var value by remember { mutableStateOf("") }
+                    var isValid by remember { mutableStateOf(false) }
+                    var enabled by remember { mutableStateOf(true) }
+                    var isFocused by remember { mutableStateOf(false) }
+                    BasicShortTextField(
+                        value = value,
+                        hint = "텍스트를 입력해주세요",
+                        isValid = isValid,
+                        enabled = enabled,
+                        onFocusChange = {
+                            isFocused = it
+                        },
+                        onValueChange = {
+                            value = it
+                            if (it == "텍스트")
+                                isValid = true
+                            if (it == "불가")
+                                enabled = false
+                        }
+                    )
+                }
+
+                item {
+                    LongTextField(
+                        value = "",
+                        onValueChange = {}
+                    )
+                }
+
+                item {
+                    LongTextField(
+                        value = "",
+                        onValueChange = {}
+                    )
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(colors.White)
+                .padding(16.dp)
+        ) {
+            LargeButton("완료") { }
+        }
+    }
+}
+
+@Preview (showBackground = true)
+@Composable
+private fun GalleryUploadScreenPreview() {
+    WithSuhyeonTheme {
+        GalleryUploadScreen()
+    }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -19,30 +19,33 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.component.bottomsheet.DeletePostBottomSheet
 import com.sopt.withsuhyeon.core.component.bottomsheet.GalleryCategoryBottomSheet
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.dropdown.text.TextDropDown
+import com.sopt.withsuhyeon.core.component.modal.AlertModal
 import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
 import com.sopt.withsuhyeon.core.component.textfield.LongTextField
 import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
-import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
 @Composable
 fun GalleryUploadRoute(
-    padding: PaddingValues
+    padding: PaddingValues,
+    popBackStackToGallery: () -> Unit
 ) {
     GalleryUploadScreen(
-        padding = padding
+        padding = padding,
+        onCompleteBtnClick = {
+            popBackStackToGallery()
+        }
     )
 }
 
@@ -50,25 +53,64 @@ fun GalleryUploadRoute(
 private fun GalleryUploadScreen(
     padding: PaddingValues,
     modifier: Modifier = Modifier,
+    onCompleteBtnClick: () -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
+    var isDeleteBottomSheetVisible by remember { mutableStateOf(false) }
+    var isDeleteAlertModalVisible by remember { mutableStateOf (false) }
+
+    if (isDeleteBottomSheetVisible) {
+        DeletePostBottomSheet(
+            isBottomSheetVisible = isDeleteBottomSheetVisible,
+            onDeleteClick = {
+                isDeleteBottomSheetVisible = false
+                isDeleteAlertModalVisible = true
+            },
+            onCloseClick = {
+                isDeleteBottomSheetVisible = false
+            },
+            onDismiss = {
+                isDeleteBottomSheetVisible = false
+            }
+        )
+    }
+
+    if (isDeleteAlertModalVisible) {
+        AlertModal(
+            onDeleteClick = {
+                isDeleteAlertModalVisible = false
+                onCompleteBtnClick()
+            },
+            onCancelClick = {
+                isDeleteAlertModalVisible = false
+            }
+        )
+    }
+
     Box(
         modifier = modifier
             .fillMaxSize()
             .padding(padding)
             .background(colors.White)
     ) {
-        SubTopNavBar(
-            text = "업로드",
-            btnIcon = painterResource(R.drawable.ic_close),
-            isTextVisible = true,
-            isBtnVisible = true,
-            onCloseBtnClicked = {},
-            modifier = modifier
+        Column(
+            modifier = Modifier
                 .fillMaxWidth()
                 .background(colors.White)
-                .align(Alignment.TopCenter)
-        )
+        ) {
+            SubTopNavBar(
+                text = "업로드",
+                btnIcon = painterResource(R.drawable.ic_menu),
+                isTextVisible = true,
+                isBtnVisible = true,
+                onCloseBtnClicked = {
+                    isDeleteBottomSheetVisible = true
+                },
+                modifier = modifier
+                    .fillMaxWidth()
+                    .background(colors.White)
+            )
+        }
 
         Column(
             modifier = modifier
@@ -188,15 +230,10 @@ private fun GalleryUploadScreen(
                 .padding(16.dp)
                 .align(BottomCenter)
         ) {
-            LargeButton("완료") { }
+            LargeButton(
+                text = "완료",
+                onClick = onCompleteBtnClick
+            )
         }
     }
 }
-
-//@Preview
-//@Composable
-//private fun GalleryUploadScreenPreview() {
-//    WithSuhyeonTheme {
-//        GalleryUploadScreen()
-//    }
-//}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -25,11 +25,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.withsuhyeon.R
-import com.sopt.withsuhyeon.core.component.bottomsheet.DeletePostBottomSheet
 import com.sopt.withsuhyeon.core.component.bottomsheet.GalleryCategoryBottomSheet
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.dropdown.text.TextDropDown
-import com.sopt.withsuhyeon.core.component.modal.AlertModal
 import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
 import com.sopt.withsuhyeon.core.component.textfield.LongTextField
 import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
@@ -60,37 +58,6 @@ private fun GalleryUploadScreen(
     onCloseBtnClick: () -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
-    var isDeleteBottomSheetVisible by remember { mutableStateOf(false) }
-    var isDeleteAlertModalVisible by remember { mutableStateOf (false) }
-
-    if (isDeleteBottomSheetVisible) {
-        DeletePostBottomSheet(
-            isBottomSheetVisible = isDeleteBottomSheetVisible,
-            onDeleteClick = {
-                isDeleteBottomSheetVisible = false
-                isDeleteAlertModalVisible = true
-            },
-            onCloseClick = {
-                isDeleteBottomSheetVisible = false
-            },
-            onDismiss = {
-                isDeleteBottomSheetVisible = false
-            }
-        )
-    }
-
-    if (isDeleteAlertModalVisible) {
-        AlertModal(
-            onDeleteClick = {
-                isDeleteAlertModalVisible = false
-                onCompleteBtnClick()
-            },
-            onCancelClick = {
-                isDeleteAlertModalVisible = false
-            }
-        )
-    }
-
     Box(
         modifier = modifier
             .fillMaxSize()

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -5,113 +5,173 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.component.bottomsheet.GalleryCategoryBottomSheet
 import com.sopt.withsuhyeon.core.component.button.LargeButton
 import com.sopt.withsuhyeon.core.component.dropdown.text.TextDropDown
 import com.sopt.withsuhyeon.core.component.textfield.BasicShortTextField
 import com.sopt.withsuhyeon.core.component.textfield.LongTextField
+import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
 @Composable
 fun GalleryUploadRoute(
-    padding: PaddingValues,
-    viewModel: GalleryViewModel = hiltViewModel()
+    padding: PaddingValues
 ) {
     GalleryUploadScreen(
-        modifier = Modifier.fillMaxSize()
-            .padding(padding)
+        padding = padding
     )
 }
 
 @Composable
 private fun GalleryUploadScreen(
-    modifier: Modifier = Modifier
+    padding: PaddingValues,
+    modifier: Modifier = Modifier,
+    viewModel: GalleryViewModel = hiltViewModel()
 ) {
-    Column(
-        modifier = modifier.fillMaxSize()
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(colors.White)
     ) {
-        val value by remember { mutableStateOf("") }
-        var isError by remember { mutableStateOf(false) }
-        var errorMessage by remember { mutableStateOf("") }
-
-        Box(
-            modifier = Modifier
-                .weight(1f)
+        SubTopNavBar(
+            text = "업로드",
+            btnIcon = painterResource(R.drawable.ic_close),
+            isTextVisible = true,
+            isBtnVisible = true,
+            onCloseBtnClicked = {},
+            modifier = modifier
                 .fillMaxWidth()
+                .background(colors.White)
+                .align(Alignment.TopCenter)
+        )
+
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(top = 56.dp, bottom = 72.dp, start = 8.dp, end = 8.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                item {
-                    GalleryUploadWithPicker({})
-                }
+            var isError by remember { mutableStateOf(false) }
+            var errorMessage by remember { mutableStateOf("") }
+            var isBottomSheetVisible by remember { mutableStateOf(false) }
+            var selectedCategory by remember { mutableStateOf("") }
+            val categories = listOf(
+                "학교", "카페", "회식", "엠티", "자취방", "도서관",
+                "수영장/빠지", "바다/계곡", "스키장", "찜질방", "캠핑/글램핑",
+                "파티룸", "절/교회 수련회", "해외여행", "공항", "기타"
+            )
 
-                item {
-                    TextDropDown(
-                        value = value,
-                        hint = "눌러서 카테고리 선택하기",
-                        isError = isError,
-                        errorMessage = errorMessage,
-                        onClick = {
-                            isError = !isError
-                            if(isError)
-                                errorMessage = "필수로 입력해줘"
-                        }
-                    )
-                }
-
-                item {
-                    var value by remember { mutableStateOf("") }
-                    var isValid by remember { mutableStateOf(false) }
-                    var enabled by remember { mutableStateOf(true) }
-                    var isFocused by remember { mutableStateOf(false) }
-                    BasicShortTextField(
-                        value = value,
-                        hint = "텍스트를 입력해주세요",
-                        isValid = isValid,
-                        enabled = enabled,
-                        onFocusChange = {
-                            isFocused = it
-                        },
-                        onValueChange = {
-                            value = it
-                            if (it == "텍스트")
-                                isValid = true
-                            if (it == "불가")
-                                enabled = false
-                        }
-                    )
-                }
-
-                item {
-                    LongTextField(
-                        value = "",
-                        onValueChange = {}
-                    )
-                }
-
-                item {
-                    LongTextField(
-                        value = "",
-                        onValueChange = {}
-                    )
-                }
+            if (isBottomSheetVisible) {
+                GalleryCategoryBottomSheet(
+                    isVisible = isBottomSheetVisible,
+                    categories = categories,
+                    selectedCategory = selectedCategory,
+                    onCategoryChipClick = { category ->
+                        selectedCategory = category
+                    },
+                    onConfirmClick = {
+                        isBottomSheetVisible = false
+                    },
+                    onDismiss = {
+                        isBottomSheetVisible = false
+                    }
+                )
             }
+
+            GalleryUploadWithPicker({})
+
+            HorizontalDivider(
+                thickness = 4.dp,
+                color = colors.Grey50
+            )
+
+            Spacer(modifier = modifier.height(8.dp))
+
+            Text(
+                text = "카테고리",
+                style = typography.body03_SB,
+                color = colors.Grey600,
+                modifier = modifier.padding(horizontal = 16.dp)
+            )
+
+            TextDropDown(
+                value = selectedCategory,
+                hint = "눌러서 카테고리 선택하기",
+                isError = isError,
+                errorMessage = errorMessage,
+                onClick = {
+                    isBottomSheetVisible = true
+                },
+                modifier = modifier.padding(horizontal = 16.dp)
+            )
+
+            Text(
+                text = "제목",
+                style = typography.body03_SB,
+                color = colors.Grey600,
+                modifier = modifier.padding(horizontal = 16.dp)
+            )
+
+            var value by remember { mutableStateOf("") }
+            var isValid by remember { mutableStateOf(false) }
+            var enabled by remember { mutableStateOf(true) }
+            var isFocused by remember { mutableStateOf(false) }
+
+            BasicShortTextField(
+                value = value,
+                hint = "텍스트를 입력해주세요",
+                isValid = isValid,
+                enabled = enabled,
+                onFocusChange = {
+                    isFocused = it
+                },
+                onValueChange = {
+                    value = it
+                },
+                visibleLength = true,
+                maxLength = 30,
+                modifier = modifier.padding(horizontal = 8.dp)
+            )
+
+            Spacer(modifier = modifier.height(16.dp))
+
+            Text(
+                text = "설명 (선택)",
+                style = typography.body03_SB,
+                color = colors.Grey600,
+                modifier = modifier.padding(horizontal = 16.dp)
+            )
+
+            LongTextField(
+                value = "",
+                onValueChange = {},
+                modifier = modifier.padding(horizontal = 16.dp)
+            )
         }
 
         Box(
@@ -119,16 +179,17 @@ private fun GalleryUploadScreen(
                 .fillMaxWidth()
                 .background(colors.White)
                 .padding(16.dp)
+                .align(BottomCenter)
         ) {
             LargeButton("완료") { }
         }
     }
 }
 
-@Preview (showBackground = true)
-@Composable
-private fun GalleryUploadScreenPreview() {
-    WithSuhyeonTheme {
-        GalleryUploadScreen()
-    }
-}
+//@Preview
+//@Composable
+//private fun GalleryUploadScreenPreview() {
+//    WithSuhyeonTheme {
+//        GalleryUploadScreen()
+//    }
+//}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sopt.withsuhyeon.R
@@ -58,6 +59,18 @@ private fun GalleryUploadScreen(
     onCloseBtnClick: () -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
+    var titleValue by remember { mutableStateOf("") }
+    var isTitleValid by remember { mutableStateOf(true) }
+    val titleErrorMessage = if (!isTitleValid) "필수로 입력해줘" else ""
+
+    var selectedCategory by remember { mutableStateOf("") }
+    var hoveredCategory by remember { mutableStateOf("") }
+    var isCategoryValid by remember { mutableStateOf(true) }
+    val categoryErrorMessage = if (!isCategoryValid) "필수로 입력해줘" else ""
+
+    var galleryUploadDescription by remember { mutableStateOf("") }
+    var isBottomSheetVisible by remember { mutableStateOf(false) }
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -70,7 +83,7 @@ private fun GalleryUploadScreen(
                 .background(colors.White)
         ) {
             SubTopNavBar(
-                text = "업로드",
+                text = stringResource(R.string.gallery_sub_nav_bar_title),
                 btnIcon = painterResource(R.drawable.ic_close),
                 isTextVisible = true,
                 isBtnVisible = true,
@@ -91,26 +104,23 @@ private fun GalleryUploadScreen(
                 .padding(horizontal = 8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            var isError by remember { mutableStateOf(false) }
-            var errorMessage by remember { mutableStateOf("") }
-            var isBottomSheetVisible by remember { mutableStateOf(false) }
-            var selectedCategory by remember { mutableStateOf("") }
             val categories = listOf(
                 "학교", "카페", "회식", "엠티", "자취방", "도서관",
                 "수영장/빠지", "바다/계곡", "스키장", "찜질방", "캠핑/글램핑",
                 "파티룸", "절/교회 수련회", "해외여행", "공항", "기타"
             )
-            var galleryUploadDescription by remember { mutableStateOf("") }
 
             if (isBottomSheetVisible) {
                 GalleryCategoryBottomSheet(
                     isVisible = isBottomSheetVisible,
                     categories = categories,
-                    selectedCategory = selectedCategory,
+                    selectedCategory = hoveredCategory,
                     onCategoryChipClick = { category ->
-                        selectedCategory = category
+                        hoveredCategory = category
                     },
                     onConfirmClick = {
+                        selectedCategory = hoveredCategory
+                        isCategoryValid = selectedCategory.isNotEmpty()
                         isBottomSheetVisible = false
                     },
                     onDismiss = {
@@ -129,7 +139,7 @@ private fun GalleryUploadScreen(
             Spacer(modifier = modifier.height(8.dp))
 
             Text(
-                text = "카테고리",
+                text = stringResource(R.string.category_subtitle),
                 style = typography.body03_SB,
                 color = colors.Grey600,
                 modifier = modifier.padding(horizontal = 16.dp)
@@ -137,9 +147,9 @@ private fun GalleryUploadScreen(
 
             TextDropDown(
                 value = selectedCategory,
-                hint = "눌러서 카테고리 선택하기",
-                isError = isError,
-                errorMessage = errorMessage,
+                hint = stringResource(R.string.category_text_drop_down_hint),
+                isError = !isCategoryValid,
+                errorMessage = categoryErrorMessage,
                 onClick = {
                     isBottomSheetVisible = true
                 },
@@ -147,32 +157,32 @@ private fun GalleryUploadScreen(
             )
 
             Text(
-                text = "제목",
+                text = stringResource(R.string.post_title_subtitle),
                 style = typography.body03_SB,
                 color = colors.Grey600,
                 modifier = modifier.padding(horizontal = 16.dp)
             )
 
-            var value by remember { mutableStateOf("") }
-            var isValid by remember { mutableStateOf(false) }
-            var enabled by remember { mutableStateOf(true) }
-            var isFocused by remember { mutableStateOf(false) }
-
-            BasicShortTextField(
-                value = value,
-                hint = "텍스트를 입력해주세요",
-                isValid = isValid,
-                enabled = enabled,
-                onFocusChange = {
-                    isFocused = it
-                },
-                onValueChange = {
-                    value = it
-                },
-                visibleLength = true,
-                maxLength = 30,
-                modifier = modifier.padding(horizontal = 8.dp)
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                BasicShortTextField(
+                    value = titleValue,
+                    onValueChange = { newValue ->
+                        titleValue = newValue
+                        isTitleValid = newValue.isNotEmpty()
+                    },
+                    hint = "텍스트를 입력해주세요",
+                    isValid = isTitleValid,
+                    errorMessage = titleErrorMessage,
+                    visibleLength = true,
+                    maxLength = 30,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
 
             Spacer(modifier = modifier.height(16.dp))
 
@@ -185,6 +195,7 @@ private fun GalleryUploadScreen(
 
             LongTextField(
                 value = galleryUploadDescription,
+                hint = stringResource(R.string.post_title_description_hint),
                 onValueChange = { newDescription ->
                     galleryUploadDescription = newDescription
                 },
@@ -203,7 +214,17 @@ private fun GalleryUploadScreen(
         ) {
             LargeButton(
                 text = "완료",
-                onClick = onCompleteBtnClick
+                onClick = {
+                    val isTitleInputValid = titleValue.isNotEmpty()
+                    val isCategoryInputValid = selectedCategory.isNotEmpty()
+
+                    isTitleValid = isTitleInputValid
+                    isCategoryValid = isCategoryInputValid
+
+                    if (isTitleInputValid && isCategoryInputValid) {
+                        onCompleteBtnClick()
+                    }
+                }
             )
         }
     }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadWithPicker.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadWithPicker.kt
@@ -1,0 +1,158 @@
+package com.sopt.withsuhyeon.feature.gallery
+
+import android.Manifest
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import coil.compose.AsyncImage
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.util.modifier.noRippleClickable
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
+
+@Composable
+fun GalleryUploadWithPicker(
+    onImageSelected: (Uri?) -> Unit
+) {
+    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    val context = LocalContext.current
+
+    val photoPickerLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        selectedImageUri = uri
+        onImageSelected(uri)
+    }
+
+    val galleryLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri ->
+        selectedImageUri = uri
+        onImageSelected(uri)
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            openGallery(photoPickerLauncher, galleryLauncher)
+        } else {
+            if (!ActivityCompat.shouldShowRequestPermissionRationale(
+                    context as Activity, Manifest.permission.READ_MEDIA_IMAGES
+                )
+            ) {
+                context.showPermissionAppSettingsDialog()
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 84.dp)
+            .aspectRatio(1f)
+            .background(color = colors.Grey500, shape = RoundedCornerShape(10.dp))
+            .noRippleClickable {
+                getGalleryPermission(
+                    permissionLauncher = permissionLauncher,
+                    photoPickerLauncher = photoPickerLauncher,
+                    galleryLauncher = galleryLauncher
+                )
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        AsyncImage(
+            model = selectedImageUri,
+            contentDescription = stringResource(R.string.gallery_upload_image_description),
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+    }
+}
+
+fun getGalleryPermission(
+    permissionLauncher: ActivityResultLauncher<String>,
+    photoPickerLauncher: ActivityResultLauncher<PickVisualMediaRequest>,
+    galleryLauncher: ActivityResultLauncher<String>
+) {
+    when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
+            openGallery(photoPickerLauncher, galleryLauncher)
+        }
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> {
+            permissionLauncher.launch(Manifest.permission.READ_MEDIA_IMAGES)
+        }
+        else -> {
+            permissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+    }
+}
+
+fun openGallery(
+    photoPickerLauncher: ActivityResultLauncher<PickVisualMediaRequest>,
+    galleryLauncher: ActivityResultLauncher<String>
+) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        photoPickerLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    } else {
+        galleryLauncher.launch("image/*")
+    }
+}
+
+fun Context.showPermissionAppSettingsDialog(
+    title: String = "권한 요청",
+    message: String = "앱의 모든 기능을 사용하려면 설정에서 권한을 허용해주세요.",
+    positiveButtonText: String = "설정으로 이동",
+    negativeButtonText: String = "취소"
+) {
+    AlertDialog.Builder(this)
+        .setTitle(title)
+        .setMessage(message)
+        .setPositiveButton(positiveButtonText) { _, _ ->
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", packageName, null)
+            }
+            startActivity(intent)
+        }
+        .setNegativeButton(negativeButtonText) { dialog, _ ->
+            dialog.dismiss()
+        }
+        .create()
+        .show()
+}
+
+@Preview
+@Composable
+private fun PhotoPickerPreview() {
+    WithSuhyeonTheme {
+        GalleryUploadWithPicker {  }
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadWithPicker.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryUploadWithPicker.kt
@@ -77,7 +77,7 @@ fun GalleryUploadWithPicker(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 84.dp)
+            .padding(horizontal = 84.dp, vertical = 32.dp)
             .aspectRatio(1f)
             .background(color = colors.Grey500, shape = RoundedCornerShape(10.dp))
             .noRippleClickable {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
@@ -6,7 +6,9 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.sopt.withsuhyeon.core.navigation.MainTabRoute
+import com.sopt.withsuhyeon.core.navigation.Route
 import com.sopt.withsuhyeon.feature.gallery.GalleryRoute
+import com.sopt.withsuhyeon.feature.gallery.GalleryUploadRoute
 
 fun NavController.navigateToGallery(navOptions: NavOptions) {
     navigate(MainTabRoute.Gallery, navOptions)
@@ -17,5 +19,8 @@ fun NavGraphBuilder.galleryNavGraph(
 ) {
     composable<MainTabRoute.Gallery> {
         GalleryRoute(padding)
+    }
+    composable<Route.GalleryUpload> {
+        GalleryUploadRoute(padding)
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
@@ -14,14 +14,18 @@ fun NavController.navigateToGallery(navOptions: NavOptions) {
     navigate(MainTabRoute.Gallery, navOptions)
 }
 
+fun NavController.navigateToGalleryUpload() {
+    navigate(Route.GalleryUpload)
+}
+
 fun NavGraphBuilder.galleryNavGraph(
     padding: PaddingValues,
-    navController: NavController
+    onNavigateToGalleryUpload: () -> Unit
 ) {
     composable<MainTabRoute.Gallery> {
         GalleryRoute(
             padding = padding,
-            navController = navController
+            navigateToGalleryUpload = onNavigateToGalleryUpload
         )
     }
     composable<Route.GalleryUpload> {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
@@ -44,7 +44,8 @@ fun NavGraphBuilder.galleryNavGraph(
     }
     composable<Route.GalleryPostDetail> {
         GalleryPostDetailRoute(
-            padding = padding
+            padding = padding,
+            popBackStackToGallery = onPopBackStackToGallery
         )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
@@ -15,10 +15,14 @@ fun NavController.navigateToGallery(navOptions: NavOptions) {
 }
 
 fun NavGraphBuilder.galleryNavGraph(
-    padding: PaddingValues
+    padding: PaddingValues,
+    navController: NavController
 ) {
     composable<MainTabRoute.Gallery> {
-        GalleryRoute(padding)
+        GalleryRoute(
+            padding = padding,
+            navController = navController
+        )
     }
     composable<Route.GalleryUpload> {
         GalleryUploadRoute(padding)

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.sopt.withsuhyeon.core.navigation.MainTabRoute
 import com.sopt.withsuhyeon.core.navigation.Route
+import com.sopt.withsuhyeon.feature.gallery.GalleryPostDetailRoute
 import com.sopt.withsuhyeon.feature.gallery.GalleryRoute
 import com.sopt.withsuhyeon.feature.gallery.GalleryUploadRoute
 
@@ -18,17 +19,32 @@ fun NavController.navigateToGalleryUpload() {
     navigate(Route.GalleryUpload)
 }
 
+fun NavController.navigateToGalleryPostDetail() {
+    navigate(Route.GalleryPostDetail)
+}
+
 fun NavGraphBuilder.galleryNavGraph(
     padding: PaddingValues,
-    onNavigateToGalleryUpload: () -> Unit
+    onNavigateToGalleryUpload: () -> Unit,
+    onNavigateToGalleryPostDetail: () -> Unit,
+    onPopBackStackToGallery: () -> Unit
 ) {
     composable<MainTabRoute.Gallery> {
         GalleryRoute(
             padding = padding,
-            navigateToGalleryUpload = onNavigateToGalleryUpload
+            navigateToGalleryUpload = onNavigateToGalleryUpload,
+            navigateToGalleryPostDetail = onNavigateToGalleryPostDetail
         )
     }
     composable<Route.GalleryUpload> {
-        GalleryUploadRoute(padding)
+        GalleryUploadRoute(
+            padding = padding,
+            popBackStackToGallery = onPopBackStackToGallery
+        )
+    }
+    composable<Route.GalleryPostDetail> {
+        GalleryPostDetailRoute(
+            padding = padding
+        )
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/home/HomeScreen.kt
@@ -65,25 +65,25 @@ private fun HomeScreen(
             )
         }
 
-        if (isBottomSheetVisible) {
-            GalleryCategoryBottomSheet(
-                isVisible = isBottomSheetVisible,
-                categories = categories,
-                selectedCategories = selectedCategories,
-                onCategoryChipClick = { category ->
-                    selectedCategories = if (selectedCategories.contains(category)) {
-                        selectedCategories - category
-                    } else {
-                        selectedCategories + category
-                    }
-                },
-                onConfirmClick = {
-                    isBottomSheetVisible = false
-                },
-                onDismiss = {
-                    isBottomSheetVisible = false
-                }
-            )
-        }
+//        if (isBottomSheetVisible) {
+//            GalleryCategoryBottomSheet(
+//                isVisible = isBottomSheetVisible,
+//                categories = categories,
+//                selectedCategories = selectedCategories,
+//                onCategoryChipClick = { category ->
+//                    selectedCategories = if (selectedCategories.contains(category)) {
+//                        selectedCategories - category
+//                    } else {
+//                        selectedCategories + category
+//                    }
+//                },
+//                onConfirmClick = {
+//                    isBottomSheetVisible = false
+//                },
+//                onDismiss = {
+//                    isBottomSheetVisible = false
+//                }
+//            )
+//        }
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
@@ -14,6 +14,7 @@ import com.sopt.withsuhyeon.core.navigation.Route
 import com.sopt.withsuhyeon.feature.chat.navigation.navigateToChat
 import com.sopt.withsuhyeon.feature.findsuhyeon.navigation.navigateToFindSuhyeon
 import com.sopt.withsuhyeon.feature.gallery.navigation.navigateToGallery
+import com.sopt.withsuhyeon.feature.gallery.navigation.navigateToGalleryUpload
 import com.sopt.withsuhyeon.feature.home.navigation.navigateToHome
 import com.sopt.withsuhyeon.feature.mypage.navigation.navigateToMyPage
 import com.sopt.withsuhyeon.feature.onboarding.navigation.navigateToOnBoarding
@@ -63,6 +64,10 @@ class MainNavigator(
                 launchSingleTop = true
             }
         )
+    }
+
+    fun navigateToGalleryUpload() {
+        navController.navigateToGalleryUpload()
     }
 
     private fun popBackStack() {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
@@ -14,6 +14,7 @@ import com.sopt.withsuhyeon.core.navigation.Route
 import com.sopt.withsuhyeon.feature.chat.navigation.navigateToChat
 import com.sopt.withsuhyeon.feature.findsuhyeon.navigation.navigateToFindSuhyeon
 import com.sopt.withsuhyeon.feature.gallery.navigation.navigateToGallery
+import com.sopt.withsuhyeon.feature.gallery.navigation.navigateToGalleryPostDetail
 import com.sopt.withsuhyeon.feature.gallery.navigation.navigateToGalleryUpload
 import com.sopt.withsuhyeon.feature.home.navigation.navigateToHome
 import com.sopt.withsuhyeon.feature.mypage.navigation.navigateToMyPage
@@ -70,7 +71,11 @@ class MainNavigator(
         navController.navigateToGalleryUpload()
     }
 
-    private fun popBackStack() {
+    fun navigateToGalleryPostDetail() {
+        navController.navigateToGalleryPostDetail()
+    }
+
+    fun popBackStack() {
         navController.popBackStack()
     }
 

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
@@ -40,7 +40,7 @@ fun MainNavHost(
 
             galleryNavGraph(
                 padding = padding,
-                navController = navigator.navController
+                onNavigateToGalleryUpload = navigator::navigateToGalleryUpload
             )
             chatNavGraph(
                 padding = padding,

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
@@ -40,7 +40,9 @@ fun MainNavHost(
 
             galleryNavGraph(
                 padding = padding,
-                onNavigateToGalleryUpload = navigator::navigateToGalleryUpload
+                onNavigateToGalleryUpload = navigator::navigateToGalleryUpload,
+                onNavigateToGalleryPostDetail = navigator::navigateToGalleryPostDetail,
+                onPopBackStackToGallery = navigator::popBackStack
             )
             chatNavGraph(
                 padding = padding,

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
@@ -40,6 +40,7 @@ fun MainNavHost(
 
             galleryNavGraph(
                 padding = padding,
+                navController = navigator.navController
             )
             chatNavGraph(
                 padding = padding,

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/OnBoardingScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/onboarding/OnBoardingScreen.kt
@@ -8,11 +8,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun OnBoardingRoute(

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16,6V5.2C16,4.08 16,3.52 15.782,3.092C15.59,2.716 15.284,2.41 14.908,2.218C14.48,2 13.92,2 12.8,2H11.2C10.08,2 9.52,2 9.092,2.218C8.716,2.41 8.41,2.716 8.218,3.092C8,3.52 8,4.08 8,5.2V6M3,6H21M19,6V17.2C19,18.88 19,19.72 18.673,20.362C18.385,20.927 17.927,21.385 17.362,21.673C16.72,22 15.88,22 14.2,22H9.8C8.12,22 7.28,22 6.638,21.673C6.074,21.385 5.615,20.927 5.327,20.362C5,19.72 5,18.88 5,17.2V6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_menu.xml
+++ b/app/src/main/res/drawable/ic_menu.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,13C12.552,13 13,12.552 13,12C13,11.448 12.552,11 12,11C11.448,11 11,11.448 11,12C11,12.552 11.448,13 12,13Z"
+      android:fillColor="#000000"/>
+  <path
+      android:pathData="M12,6C12.552,6 13,5.552 13,5C13,4.448 12.552,4 12,4C11.448,4 11,4.448 11,5C11,5.552 11.448,6 12,6Z"
+      android:fillColor="#000000"/>
+  <path
+      android:pathData="M12,20C12.552,20 13,19.552 13,19C13,18.448 12.552,18 12,18C11.448,18 11,18.448 11,19C11,19.552 11.448,20 12,20Z"
+      android:fillColor="#000000"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12,13C12.552,13 13,12.552 13,12C13,11.448 12.552,11 12,11C11.448,11 11,11.448 11,12C11,12.552 11.448,13 12,13Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12,6C12.552,6 13,5.552 13,5C13,4.448 12.552,4 12,4C11.448,4 11,4.448 11,5C11,5.552 11.448,6 12,6Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M12,20C12.552,20 13,19.552 13,19C13,18.448 12.552,18 12,18C11.448,18 11,18.448 11,19C11,19.552 11.448,20 12,20Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,8 +53,9 @@
     <string name="find_suhyeon_location">위치</string>
     <string name="find_suhyeon_multi_select_chip">MultiSelectChip</string>
 
-    <!-- 공통 사용 dot -->
+    <!-- 공통 사용 dot, blank -->
     <string name="dot">・</string>
+    <string name="blank"></string>
 
     <!-- checkbox 종료 버튼 -->
     <string name="x_close_description">x 버튼</string>
@@ -69,9 +70,6 @@
     <string name="block_bottomsheet_button_text">차단하러 가기</string>
     <string name="block_bottomsheet_skip_text">괜찮아요</string>
 
-    <!-- 갤러리 뷰 -->
-    <string name="gallery_upload_image_description">Gallery Upload Image</string>
-
     <!-- 공통 컴포넌트 - Top Nav Bar -->
     <string name="top_nav_bar_btn_icon_description">Top Nav Bar Btn Icon</string>
 
@@ -82,6 +80,13 @@
     <!-- 갤러리 -->
     <string name="gallery_top_nav_bar_title">갤러리</string>
     <string name="gallery_main_category_chip_total">전체</string>
+    <string name="gallery_upload_image_description">Gallery Upload Image</string>
+    <string name="gallery_sub_nav_bar_title">업로드</string>
+    <string name="category_subtitle">카테고리</string>
+    <string name="category_text_drop_down_hint">눌러서 카테고리 선택하기</string>
+    <string name="post_title_subtitle">제목</string>
+    <string name="post_title_description_hint">텍스트를 입력해주세요</string>
+    <string name="post_description_subtitle">설명 (선택)</string>
 
     <!-- 공통 컴포넌트 - 게시글 -->
     <string name="post_basic_profile_image_description">Basic Profile Image</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="post_title_subtitle">제목</string>
     <string name="post_title_description_hint">텍스트를 입력해주세요</string>
     <string name="post_description_subtitle">설명 (선택)</string>
+    <string name="gallery_download_btn">다운로드</string>
 
     <!-- 공통 컴포넌트 - 게시글 -->
     <string name="post_basic_profile_image_description">Basic Profile Image</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,7 @@
     <string name="block_bottomsheet_sub_title">차단하고자하는 전화번호를 입력해주시면,\n앱내에서 숨기기 처리됩니다.</string>
     <string name="block_bottomsheet_button_text">차단하러 가기</string>
     <string name="block_bottomsheet_skip_text">괜찮아요</string>
+
+    <!-- 갤러리 뷰 -->
+    <string name="gallery_upload_image_description">Gallery Upload Image</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #30

## Work Description 📝
- 멀티파트 - 갤러리 이미지 퍼미션 분기처리 세팅
- 갤러리 업로드 뷰 구현
- 갤러리 게시물 상세 뷰 구현
- 갤러리 DeleteBottomSheet 공통 컴포넌트 구현
- 갤러리 플로우 전체 navigation
- 갤러리 에러 처리 분기처리, 상세 UI 로직 수정

## Screenshot 📸
https://github.com/user-attachments/assets/04874eb3-87b3-42ff-800b-5c968e7ae274

https://github.com/user-attachments/assets/dc1d86f8-e999-41e9-8f1e-f7509827d4fc


## Uncompleted Tasks 😅
- [ ] BasicShortTextField 수정 여부 - 클릭된 적이 없을 때에는, 에러 상태여도 borderColor가 Red01이 되지 않는 경우가 발생함

## To Reviewers 📢
갤러리 뷰 및 네비게이션 로직, 업로드 뷰 에러 처리 분기처리 구현하였습니다.
로컬 갤러리의 이미지를 업로드할 수 있는 퍼미션 처리를, SDK 버전에 따라 분기처리 구현하였습니다.
(따라서 기기마다 SDK 버전에 따라 서로 다른 포토피커 및 권한 설정 모달이 뜨게 되고, 각 기기에 따라 권한 허용 처리를 해준 후 이미지 선택을 해주면 됩니다!)