### PR TITLE
[FEAT/#53] 갤러리 뷰 API 연동

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
     <uses-permission

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/bottomsheet/DeletePostBottomSheet.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/bottomsheet/DeletePostBottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.sopt.withsuhyeon.core.component.bottomsheet.draghandle.BottomSheetDragHandle
 import com.sopt.withsuhyeon.core.component.button.DeleteLargeButton
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
@@ -26,7 +27,8 @@ fun DeletePostBottomSheet(
         ModalBottomSheet(
             onDismissRequest = { onDismiss() },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-            containerColor = colors.White
+            containerColor = colors.White,
+            dragHandle = { BottomSheetDragHandle() }
         ) {
             DeleteLargeButton(
                 text = "삭제하기",

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/card/GalleryMainCardItem.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/card/GalleryMainCardItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -34,6 +35,7 @@ fun GalleryMainCardItem(
         AsyncImage(
             model = image,
             contentDescription = null,
+            contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(180.dp)
                 .clip(RoundedCornerShape(20.dp))

--- a/app/src/main/java/com/sopt/withsuhyeon/core/component/chip/NewCategoryChip.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/component/chip/NewCategoryChip.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -23,12 +25,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.sopt.withsuhyeon.R
+import com.sopt.withsuhyeon.core.util.KeyStorage.ETC
+import com.sopt.withsuhyeon.core.util.KeyStorage.MT
+import com.sopt.withsuhyeon.core.util.KeyStorage.TOTAL
 import com.sopt.withsuhyeon.core.util.modifier.noRippleClickable
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
+import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
 @Composable
 fun NewCategoryChip(
@@ -101,13 +109,34 @@ fun NewCategoryChip(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (category == "전체") {
+                if (category == TOTAL) {
                     Text(
-                        text = "ALL",
-                        fontSize = 14.sp,
+                        text = stringResource(R.string.category_chip_all),
+                        fontSize = 16.sp,
                         fontWeight = FontWeight.Bold,
                         color = if (isSelected) Color.White else colors.Purple500,
                         modifier = Modifier
+                            .width(allTextWidth.dp)
+                            .alpha(allTextOpacity)
+                    )
+                }
+                else if (category == MT) {
+                    Text(
+                        text = stringResource(R.string.category_chip_mt),
+                        style = typography.title03_B,
+                        color = if (isSelected) Color.White else colors.Purple500,
+                        modifier = Modifier
+                            .width(allTextWidth.dp)
+                            .alpha(allTextOpacity)
+                    )
+                }
+                else if (category == ETC) {
+                    Text(
+                        text = stringResource(R.string.category_chip_etc),
+                        style = typography.body03_B,
+                        color = if (isSelected) Color.White else colors.Purple500,
+                        modifier = Modifier
+                            .padding(8.dp)
                             .width(allTextWidth.dp)
                             .alpha(allTextOpacity)
                     )
@@ -122,8 +151,7 @@ fun NewCategoryChip(
 
                 Text(
                     text = category,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.SemiBold,
+                    style = typography.body03_SB,
                     color = chipTextColor,
                     maxLines = 1,
                     modifier = Modifier
@@ -133,11 +161,12 @@ fun NewCategoryChip(
             }
         }
 
+        Spacer(modifier = Modifier.height(6.dp))
+
         Text(
             text = category,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Bold,
-            color = if (isSelected) colors.Purple500 else colors.Grey400,
+            style = typography.body03_B,
+            color = if (isSelected) colors.Purple600 else colors.Grey400,
             modifier = Modifier
                 .height(textHeight.dp)
                 .alpha(outsideTextOpacity)

--- a/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/navigation/RouteModel.kt
@@ -16,7 +16,7 @@ sealed interface Route {
     @Serializable
     data object GalleryUpload : Route
     @Serializable
-    data object GalleryPostDetail : Route
+    data class GalleryPostDetail(val galleryId: Long) : Route
     @Serializable
     data object SelectGender : Route
     @Serializable

--- a/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/util/KeyStorage.kt
@@ -45,4 +45,8 @@ object KeyStorage {
 
     const val LOGOUT_ALERT_TYPE = "logout"
     const val LEAVE_ALERT_TYPE = "leave"
+
+    const val TOTAL = "전체"
+    const val MT = "엠티"
+    const val ETC = "기타"
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/core/util/image/downloadImage.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/core/util/image/downloadImage.kt
@@ -1,0 +1,47 @@
+package com.sopt.withsuhyeon.core.util.image
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import android.provider.MediaStore
+import android.widget.Toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.io.OutputStream
+import java.net.URL
+
+fun downloadImage(context: Context, imageUrl: String, fileName: String, onSuccess: () -> Unit) {
+    CoroutineScope(Dispatchers.IO).launch {
+        try {
+            val inputStream = URL(imageUrl).openStream()
+            val values = ContentValues().apply {
+                put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+                put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+                put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + "/MyApp")
+            }
+
+            val resolver = context.contentResolver
+            val uri: Uri? = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+            if (uri != null) {
+                val outputStream: OutputStream? = resolver.openOutputStream(uri)
+                outputStream.use { out ->
+                    inputStream.copyTo(out!!)
+                }
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, "다운로드 완료되었습니다", Toast.LENGTH_SHORT).show()
+                    onSuccess()
+                }
+            } else {
+                throw IOException("다운로드 실패했습니다")
+            }
+        } catch (e: Exception) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, "다운로드 실패: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sopt/withsuhyeon/data/datasource/GalleryDataSource.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/datasource/GalleryDataSource.kt
@@ -12,4 +12,5 @@ interface GalleryDataSource {
     suspend fun getGalleryTotal(category: String): BaseResponse<ResponseGalleryTotalDto>
     suspend fun uploadGallery(image: MultipartBody.Part, request: RequestBody) : BaseResponse<Unit>
     suspend fun getGalleryPostDetail(galleryId: Long): BaseResponse<ResponseGalleryPostDetailDto>
+    suspend fun deleteGalleryPost(galleryId: Long): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/data/datasourceimpl/GalleryDataSourceImpl.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/datasourceimpl/GalleryDataSourceImpl.kt
@@ -24,4 +24,7 @@ class GalleryDataSourceImpl @Inject constructor(
 
     override suspend fun getGalleryPostDetail(galleryId: Long): BaseResponse<ResponseGalleryPostDetailDto> =
        galleryService.getGalleryPostDetail(galleryId)
+
+    override suspend fun deleteGalleryPost(galleryId: Long): BaseResponse<Unit> =
+        galleryService.deleteGalleryPost(galleryId)
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/data/mapper/GalleryPostDetailMapper.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/mapper/GalleryPostDetailMapper.kt
@@ -11,6 +11,7 @@ fun ResponseGalleryPostDetailDto.toGalleryPostDetailModel(): GalleryPostDetailMo
         profileImage = this.profileImage,
         nickname = this.nickname,
         createdAt = this.createdAt,
-        content = this.content
+        content = this.content,
+        owner = this.owner
     )
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/data/repositoryimpl/GalleryRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/repositoryimpl/GalleryRepositoryImpl.kt
@@ -36,4 +36,10 @@ class GalleryRepositoryImpl @Inject constructor(
             val response = galleryService.getGalleryPostDetail(galleryId)
             response.result?.toGalleryPostDetailModel() ?: throw Exception("Response data is null")
         }
+
+    override suspend fun deleteGalleryPost(galleryId: Long): Result<Unit> =
+        runCatching {
+            val response = galleryService.deleteGalleryPost(galleryId)
+            response.result
+        }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/data/repositoryimpl/GalleryRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/repositoryimpl/GalleryRepositoryImpl.kt
@@ -25,6 +25,12 @@ class GalleryRepositoryImpl @Inject constructor(
             response.result?.galleries ?: throw Exception("Response data is null")
         }
 
+    override suspend fun getAllGalleries(): Result<List<Gallery>> =
+        runCatching {
+            val response = galleryService.getGalleryTotal("")
+            response.result?.galleries ?: throw Exception("Response data is null")
+        }
+
     override suspend fun uploadGallery(image: MultipartBody.Part, request: RequestBody): Result<Unit> =
         runCatching {
             val response = galleryService.uploadGallery(image, request)

--- a/app/src/main/java/com/sopt/withsuhyeon/data/service/GalleryService.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/service/GalleryService.kt
@@ -20,7 +20,7 @@ interface GalleryService {
 
     @GET("/api/v1/galleries")
     suspend fun getGalleryTotal(
-        @Query("category") category: String
+        @Query("category") category: String = ""
     ) : BaseResponse<ResponseGalleryTotalDto>
 
     @Multipart

--- a/app/src/main/java/com/sopt/withsuhyeon/data/service/GalleryService.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/service/GalleryService.kt
@@ -6,6 +6,7 @@ import com.sopt.withsuhyeon.data.dto.response.ResponseGalleryPostDetailDto
 import com.sopt.withsuhyeon.data.dto.response.ResponseGalleryTotalDto
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
@@ -33,4 +34,9 @@ interface GalleryService {
     suspend fun getGalleryPostDetail(
         @Path("galleryId") galleryId: Long
     ) : BaseResponse<ResponseGalleryPostDetailDto>
+
+    @DELETE("/api/v1/galleries/{galleryId}")
+    suspend fun deleteGalleryPost(
+        @Path("galleryId") galleryId: Long
+    ) : BaseResponse<Unit>
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/data/service/GalleryService.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/data/service/GalleryService.kt
@@ -29,7 +29,7 @@ interface GalleryService {
         @Part("createGalleryRequest") request: RequestBody
     ) : BaseResponse<Unit>
 
-    @GET("/api/v1/galleries")
+    @GET("/api/v1/galleries/{galleryId}")
     suspend fun getGalleryPostDetail(
         @Path("galleryId") galleryId: Long
     ) : BaseResponse<ResponseGalleryPostDetailDto>

--- a/app/src/main/java/com/sopt/withsuhyeon/domain/entity/GalleryPostDetailModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/domain/entity/GalleryPostDetailModel.kt
@@ -1,11 +1,22 @@
 package com.sopt.withsuhyeon.domain.entity
 
+import kotlinx.serialization.SerialName
+
 data class GalleryPostDetailModel(
+    @SerialName("imageUrl")
     val imageUrl: String,
+    @SerialName("category")
     val category: String,
+    @SerialName("title")
     val title: String,
+    @SerialName("profileImage")
     val profileImage: String,
+    @SerialName("nickname")
     val nickname: String,
+    @SerialName("createdAt")
     val createdAt: String,
-    val content: String
+    @SerialName("content")
+    val content: String,
+    @SerialName("owner")
+    val owner: Boolean
 )

--- a/app/src/main/java/com/sopt/withsuhyeon/domain/repository/GalleryRepository.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/domain/repository/GalleryRepository.kt
@@ -9,6 +9,7 @@ import okhttp3.RequestBody
 interface GalleryRepository {
     suspend fun getGalleryCategories() : Result<List<Category>>
     suspend fun getGalleryTotal(category: String) : Result<List<Gallery>>
+    suspend fun getAllGalleries(): Result<List<Gallery>>
     suspend fun uploadGallery(image: MultipartBody.Part, request: RequestBody) : Result<Unit>
     suspend fun getGalleryPostDetail(galleryId: Long) : Result<GalleryPostDetailModel>
     suspend fun deleteGalleryPost(galleryId: Long) : Result<Unit>

--- a/app/src/main/java/com/sopt/withsuhyeon/domain/repository/GalleryRepository.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/domain/repository/GalleryRepository.kt
@@ -11,4 +11,5 @@ interface GalleryRepository {
     suspend fun getGalleryTotal(category: String) : Result<List<Gallery>>
     suspend fun uploadGallery(image: MultipartBody.Part, request: RequestBody) : Result<Unit>
     suspend fun getGalleryPostDetail(galleryId: Long) : Result<GalleryPostDetailModel>
+    suspend fun deleteGalleryPost(galleryId: Long) : Result<Unit>
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -170,6 +170,7 @@ fun GalleryPostDetailScreen(
                 profileImage = galleryPostDetail.profileImage,
                 userName = galleryPostDetail.nickname,
                 date = galleryPostDetail.createdAt,
+                modifier = Modifier.padding(start = 16.dp)
             )
 
             HorizontalDivider(

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -37,6 +38,7 @@ import com.sopt.withsuhyeon.core.component.modal.AlertModal
 import com.sopt.withsuhyeon.core.component.profile.PostProfileInfoRow
 import com.sopt.withsuhyeon.core.component.topbar.SubTopNavBar
 import com.sopt.withsuhyeon.core.type.MediumChipType
+import com.sopt.withsuhyeon.core.util.image.downloadImage
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 
@@ -69,10 +71,10 @@ fun GalleryPostDetailScreen(
     viewModel: GalleryPostDetailViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
 ) {
-
     LaunchedEffect(galleryId) {
         viewModel.getGalleryPostDetail(galleryId)
     }
+    val context = LocalContext.current
 
     var isDeleteBottomSheetVisible by remember { mutableStateOf(false) }
     var isDeleteAlertModalVisible by remember { mutableStateOf (false) }
@@ -198,7 +200,16 @@ fun GalleryPostDetailScreen(
         ) {
             LargeButton(
                 text = stringResource(R.string.gallery_download_btn),
-                onClick = onDownloadBtnClick,
+                onClick = {
+                    val fileName = "image_${System.currentTimeMillis()}.jpg"
+                    downloadImage(
+                        context = context,
+                        imageUrl = galleryPostDetail.imageUrl,
+                        fileName = fileName
+                    ) {
+                        onDownloadBtnClick()
+                    }
+                },
                 isDownloadBtn = true,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -53,6 +53,9 @@ fun GalleryPostDetailRoute(
         onDownloadBtnClick = {
             popBackStackToGallery()
         },
+        onModalDeleteBtnClick = {
+            popBackStackToGallery()
+        },
         viewModel = viewModel
     )
 }
@@ -61,6 +64,7 @@ fun GalleryPostDetailRoute(
 fun GalleryPostDetailScreen(
     padding: PaddingValues,
     onDownloadBtnClick: () -> Unit,
+    onModalDeleteBtnClick: () -> Unit,
     galleryId: Long,
     viewModel: GalleryPostDetailViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
@@ -95,7 +99,8 @@ fun GalleryPostDetailScreen(
         AlertModal(
             onDeleteClick = {
                 isDeleteAlertModalVisible = false
-                onDownloadBtnClick()
+                viewModel.deleteGalleryPost(galleryId)
+                onModalDeleteBtnClick()
             },
             onCancelClick = {
                 isDeleteAlertModalVisible = false

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,10 +23,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
 import com.sopt.withsuhyeon.R
 import com.sopt.withsuhyeon.core.component.bottomsheet.DeletePostBottomSheet
 import com.sopt.withsuhyeon.core.component.button.LargeButton
@@ -41,13 +44,16 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.typography
 fun GalleryPostDetailRoute(
     padding: PaddingValues,
     popBackStackToGallery: () -> Unit,
-    viewModel: GalleryViewModel = hiltViewModel()
+    galleryId: Long,
+    viewModel: GalleryPostDetailViewModel = hiltViewModel()
 ) {
     GalleryPostDetailScreen(
         padding = padding,
+        galleryId = galleryId,
         onDownloadBtnClick = {
             popBackStackToGallery()
-        }
+        },
+        viewModel = viewModel
     )
 }
 
@@ -55,9 +61,15 @@ fun GalleryPostDetailRoute(
 fun GalleryPostDetailScreen(
     padding: PaddingValues,
     onDownloadBtnClick: () -> Unit,
+    galleryId: Long,
     viewModel: GalleryPostDetailViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
 ) {
+
+    LaunchedEffect(galleryId) {
+        viewModel.getGalleryPostDetail(galleryId)
+    }
+
     var isDeleteBottomSheetVisible by remember { mutableStateOf(false) }
     var isDeleteAlertModalVisible by remember { mutableStateOf (false) }
 
@@ -118,11 +130,14 @@ fun GalleryPostDetailScreen(
                 .verticalScroll(rememberScrollState())
                 .background(colors.White)
         ) {
-            Box(
+            AsyncImage(
+                model = galleryPostDetail.imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(1f)
-                    .background(colors.Grey500)
+                    .background(colors.Grey50)
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailViewModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.sopt.withsuhyeon.feature.gallery
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sopt.withsuhyeon.domain.entity.GalleryPostDetailModel
@@ -25,7 +26,8 @@ class GalleryPostDetailViewModel @Inject constructor(
             profileImage = "",
             nickname = "",
             createdAt = "",
-            content = ""
+            content = "",
+            owner = true
         )
     )
     val galleryPostDetail: StateFlow<GalleryPostDetailModel> = _galleryPostDetail.asStateFlow()
@@ -44,7 +46,8 @@ class GalleryPostDetailViewModel @Inject constructor(
                         profileImage = data.profileImage,
                         nickname = data.nickname,
                         createdAt = data.createdAt,
-                        content = data.content
+                        content = data.content,
+                        owner = data.owner
                     )
                 }
                 .onFailure { error ->

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailViewModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryPostDetailViewModel.kt
@@ -55,4 +55,16 @@ class GalleryPostDetailViewModel @Inject constructor(
                 }
         }
     }
+
+    fun deleteGalleryPost(galleryId: Long) {
+        viewModelScope.launch {
+            galleryRepository.deleteGalleryPost(galleryId)
+                .onSuccess {
+                    Log.d("갤러리 삭제", "성공")
+                }
+                .onFailure {
+                    Log.d("갤러리 삭제", "실패")
+                }
+        }
+    }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -114,7 +114,7 @@ private fun GalleryScreen(
                 ) {
                     item {
                         NewCategoryChip(
-                            imageUrl = "https://example.com/default-image.jpg",
+                            imageUrl = "",
                             category = "전체",
                             scrollOffset = lazyGridState.firstVisibleItemScrollOffset.toFloat(),
                             isSelected = selectedCategory == "전체",

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -43,7 +43,7 @@ import com.sopt.withsuhyeon.ui.theme.WithSuhyeonTheme.colors
 fun GalleryRoute(
     padding: PaddingValues,
     navigateToGalleryUpload: () -> Unit,
-    navigateToGalleryPostDetail: () -> Unit,
+    navigateToGalleryPostDetail: (Long) -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
     GalleryScreen(
@@ -51,8 +51,8 @@ fun GalleryRoute(
         onFloatingButtonClick = {
             navigateToGalleryUpload()
         },
-        onGalleryCardItemClick = {
-            navigateToGalleryPostDetail()
+        onGalleryCardItemClick = { galleryId ->
+            navigateToGalleryPostDetail(galleryId)
         }
     )
 }
@@ -61,7 +61,7 @@ fun GalleryRoute(
 private fun GalleryScreen(
     padding: PaddingValues,
     onFloatingButtonClick: () -> Unit,
-    onGalleryCardItemClick: () -> Unit,
+    onGalleryCardItemClick: (Long) -> Unit,
     viewModel: GalleryViewModel = hiltViewModel()
 ) {
     val lazyGridState = rememberLazyGridState()
@@ -159,7 +159,7 @@ private fun GalleryScreen(
                         text = gallery.title,
                         image = gallery.imageUrl,
                         onClick = {
-                            onGalleryCardItemClick()
+                            onGalleryCardItemClick(gallery.galleryId)
                         },
                         modifier = Modifier
                     )

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -77,17 +77,14 @@ private fun GalleryScreen(
 
     val categories by viewModel.categories.collectAsState()
     val galleries by viewModel.galleries.collectAsState()
-    var selectedCategory by remember { mutableStateOf("전체") }
+    val selectedCategory by viewModel.selectedCategory.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.getGalleryCategories()
-        viewModel.getGalleryTotal("전체")
     }
 
     LaunchedEffect(selectedCategory) {
-        selectedCategory.let {
-            viewModel.getGalleryTotal(it)
-        }
+        viewModel.getGalleryTotal(selectedCategory)
     }
 
     Box(
@@ -124,7 +121,7 @@ private fun GalleryScreen(
                             scrollOffset = lazyGridState.firstVisibleItemScrollOffset.toFloat(),
                             isSelected = selectedCategory == "전체",
                             onClick = {
-                                selectedCategory = "전체"
+                                viewModel.setSelectedCategory("전체")
                             }
                         )
                     }
@@ -135,7 +132,7 @@ private fun GalleryScreen(
                             scrollOffset = lazyGridState.firstVisibleItemScrollOffset.toFloat(),
                             isSelected = selectedCategory == category.category,
                             onClick = {
-                                selectedCategory = category.category
+                                viewModel.setSelectedCategory(category.category)
                             }
                         )
                     }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryScreen.kt
@@ -23,9 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomEnd
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
@@ -31,6 +31,9 @@ class GalleryViewModel @Inject constructor(
     private val _galleryPostDetail = MutableStateFlow<GalleryPostDetailModel?>(null)
     val galleryPostDetail: StateFlow<GalleryPostDetailModel?> = _galleryPostDetail.asStateFlow()
 
+    private val _selectedCategory = MutableStateFlow("전체")
+    val selectedCategory: StateFlow<String> = _selectedCategory.asStateFlow()
+
     init {
         getGalleryCategories()
     }
@@ -57,5 +60,9 @@ class GalleryViewModel @Inject constructor(
                     _errorMessage.update { error.message }
                 }
         }
+    }
+
+    fun setSelectedCategory(category: String) {
+        _selectedCategory.value = category
     }
 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
@@ -52,7 +52,13 @@ class GalleryViewModel @Inject constructor(
 
     fun getGalleryTotal(category: String) {
         viewModelScope.launch {
-            galleryRepository.getGalleryTotal(category)
+            val result = if (category == "전체") {
+                galleryRepository.getAllGalleries()
+            } else {
+                galleryRepository.getGalleryTotal(category)
+            }
+
+            result
                 .onSuccess { galleries ->
                     _galleries.update { galleries }
                 }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
@@ -2,6 +2,7 @@ package com.sopt.withsuhyeon.feature.gallery
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sopt.withsuhyeon.core.util.KeyStorage.TOTAL
 import com.sopt.withsuhyeon.domain.entity.Category
 import com.sopt.withsuhyeon.domain.entity.Gallery
 import com.sopt.withsuhyeon.domain.entity.GalleryPostDetailModel
@@ -31,7 +32,7 @@ class GalleryViewModel @Inject constructor(
     private val _galleryPostDetail = MutableStateFlow<GalleryPostDetailModel?>(null)
     val galleryPostDetail: StateFlow<GalleryPostDetailModel?> = _galleryPostDetail.asStateFlow()
 
-    private val _selectedCategory = MutableStateFlow("전체")
+    private val _selectedCategory = MutableStateFlow(TOTAL)
     val selectedCategory: StateFlow<String> = _selectedCategory.asStateFlow()
 
     init {
@@ -52,7 +53,7 @@ class GalleryViewModel @Inject constructor(
 
     fun getGalleryTotal(category: String) {
         viewModelScope.launch {
-            val result = if (category == "전체") {
+            val result = if (category == TOTAL) {
                 galleryRepository.getAllGalleries()
             } else {
                 galleryRepository.getGalleryTotal(category)

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/GalleryViewModel.kt
@@ -25,24 +25,11 @@ class GalleryViewModel @Inject constructor(
     private val _galleries = MutableStateFlow<List<Gallery>>(emptyList())
     val galleries: StateFlow<List<Gallery>> = _galleries.asStateFlow()
 
-//    private val _selectedCategory = MutableStateFlow<String?>(null)
-//    val selectedCategory: StateFlow<String?> = _selectedCategory.asStateFlow()
-
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
-    private val _galleryPostDetail = MutableStateFlow(
-        GalleryPostDetailModel(
-            imageUrl = "",
-            category = "",
-            title = "",
-            profileImage = "",
-            nickname = "",
-            createdAt = "",
-            content = ""
-        )
-    )
-    val galleryPostDetail: StateFlow<GalleryPostDetailModel> = _galleryPostDetail.asStateFlow()
+    private val _galleryPostDetail = MutableStateFlow<GalleryPostDetailModel?>(null)
+    val galleryPostDetail: StateFlow<GalleryPostDetailModel?> = _galleryPostDetail.asStateFlow()
 
     init {
         getGalleryCategories()

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/gallery/navigation/GalleryNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.sopt.withsuhyeon.core.navigation.MainTabRoute
 import com.sopt.withsuhyeon.core.navigation.Route
 import com.sopt.withsuhyeon.feature.gallery.GalleryPostDetailRoute
@@ -19,21 +20,23 @@ fun NavController.navigateToGalleryUpload() {
     navigate(Route.GalleryUpload)
 }
 
-fun NavController.navigateToGalleryPostDetail() {
-    navigate(Route.GalleryPostDetail)
+fun NavController.navigateToGalleryPostDetail(galleryId: Long) {
+    navigate(Route.GalleryPostDetail(galleryId))
 }
 
 fun NavGraphBuilder.galleryNavGraph(
     padding: PaddingValues,
     onNavigateToGalleryUpload: () -> Unit,
-    onNavigateToGalleryPostDetail: () -> Unit,
+    onNavigateToGalleryPostDetail: (Long) -> Unit,
     onPopBackStackToGallery: () -> Unit
 ) {
     composable<MainTabRoute.Gallery> {
         GalleryRoute(
             padding = padding,
             navigateToGalleryUpload = onNavigateToGalleryUpload,
-            navigateToGalleryPostDetail = onNavigateToGalleryPostDetail
+            navigateToGalleryPostDetail = { galleryId ->
+                onNavigateToGalleryPostDetail(galleryId)
+            }
         )
     }
     composable<Route.GalleryUpload> {
@@ -42,9 +45,11 @@ fun NavGraphBuilder.galleryNavGraph(
             popBackStackToGallery = onPopBackStackToGallery
         )
     }
-    composable<Route.GalleryPostDetail> {
+    composable<Route.GalleryPostDetail> { navBackStackEntry ->
+        val galleryId = navBackStackEntry.toRoute<Route.GalleryPostDetail>().galleryId
         GalleryPostDetailRoute(
             padding = padding,
+            galleryId = galleryId,
             popBackStackToGallery = onPopBackStackToGallery
         )
     }

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/MainNavigator.kt
@@ -144,8 +144,8 @@ class MainNavigator(
         navController.navigateToGalleryUpload()
     }
 
-    fun navigateToGalleryPostDetail() {
-        navController.navigateToGalleryPostDetail()
+    fun navigateToGalleryPostDetail(galleryId: Long) {
+        navController.navigateToGalleryPostDetail(galleryId)
     }
 
     fun navigateToChatRoom() {

--- a/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/sopt/withsuhyeon/feature/main/component/MainNavHost.kt
@@ -66,7 +66,7 @@ fun MainNavHost(
             galleryNavGraph(
                 padding = padding,
                 onNavigateToGalleryUpload = navigator::navigateToGalleryUpload,
-                onNavigateToGalleryPostDetail = navigator::navigateToGalleryPostDetail,
+                onNavigateToGalleryPostDetail = { navigator.navigateToGalleryPostDetail(it) },
                 onPopBackStackToGallery = navigator::popBackStack
             )
             chatNavGraph(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,4 +214,9 @@
     <string name="onboarding_account_question">이미 계정이 있나요?</string>
     <string name="onboarding_login_text">로그인</string>
     <string name="onboarding_start_text">시작하기</string>
+
+    <!-- 카테고리 칩 -->
+    <string name="category_chip_all">ALL</string>
+    <string name="category_chip_mt">MT</string>
+    <string name="category_chip_etc"> etc.</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #53 

## Work Description 📝
- 전체 갤러리 카테고리 조회 API
- 갤러리 업로드 API
- 전체 갤러리 조회 API
- 갤러리 상세 조회 API
- 갤러리 삭제 API

## Screenshot 📸
https://github.com/user-attachments/assets/7142a92a-b557-48c6-a682-d5f0de736abe

[갤러리 삭제 api.webm](https://github.com/user-attachments/assets/375bffcb-5301-43d2-8bfb-a7ca8822b531)


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
갤러리 뷰 API 연동 완료하였습니다.
아직 토스트 메시지 커스텀은 안 했는데, 그건 추후 반영하겠습니다.